### PR TITLE
Don't 500 when login provider gives us an error

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,6 +6,7 @@ from flask_login import LoginManager
 from flask_mail import Mail
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
+from raven.contrib.flask import Sentry
 from .config import config
 
 bootstrap = Bootstrap()
@@ -13,6 +14,7 @@ mail = Mail()
 db = SQLAlchemy()
 migrate = Migrate()
 cache = Cache()
+sentry = Sentry()
 
 login_manager = LoginManager()
 login_manager.session_protection = 'strong'
@@ -43,7 +45,6 @@ def create_app(config_name):
     sentry = None
     if app.config.get('SENTRY_ENABLE'):
         app.logger.info("Using Sentry")
-        from raven.contrib.flask import Sentry
         sentry = Sentry(app)
 
     @app.errorhandler(500)

--- a/app/auth/oauth.py
+++ b/app/auth/oauth.py
@@ -102,6 +102,10 @@ class GoogleSignIn(OAuthSignIn):
                 decoder=json.loads
         )
         me = oauth_session.get('').json()
+
+        if 'sub' not in me:
+            raise ValueError("Error with OAuth callback: {}".format(me))
+
         return (
             'google$' + me['sub'],
             me['name'],


### PR DESCRIPTION
Looks like Google gave us an error while logging in on staging. This checks for that and raises a useful error rather than 500'ing.

From https://sentry.io/ragtag/carpools-staging/issues/358346975/