### PR TITLE
Warn about deletion of destinations if carpools are connected to it

### DIFF
--- a/app/admin/views.py
+++ b/app/admin/views.py
@@ -230,7 +230,11 @@ def destinations_delete(uuid):
     delete_form = DeleteDestinationForm()
     if delete_form.validate_on_submit():
         if delete_form.submit.data:
-            # TODO Check to make sure no one is using the destination?
+            if dest.carpools:
+                flash("This destination cannot be deleted because "
+                      "some carpools still use it", 'error')
+                return redirect(url_for('admin.destinations_show', uuid=uuid))
+
             db.session.delete(dest)
             db.session.commit()
 

--- a/app/admin/views.py
+++ b/app/admin/views.py
@@ -230,11 +230,6 @@ def destinations_delete(uuid):
     delete_form = DeleteDestinationForm()
     if delete_form.validate_on_submit():
         if delete_form.submit.data:
-            if dest.carpools:
-                flash("This destination cannot be deleted because "
-                      "some carpools still use it", 'error')
-                return redirect(url_for('admin.destinations_show', uuid=uuid))
-
             db.session.delete(dest)
             db.session.commit()
 

--- a/app/models.py
+++ b/app/models.py
@@ -183,6 +183,8 @@ class Destination(db.Model, UuidMixin):
     name = db.Column(db.String(80))
     address = db.Column(db.String(300))
 
+    carpools = relationship("Carpool", cascade="all, delete-orphan")
+
     @classmethod
     def find_all_visible(clz):
         return clz.query.filter(clz.hidden != True)

--- a/app/templates/admin/destinations/delete.html
+++ b/app/templates/admin/destinations/delete.html
@@ -6,6 +6,20 @@
 <h3>Destinations</h3>
 
 <p>
+    {% set count=dest.carpools|length %}
+    {% if count == 1 %}
+    There is <strong>{{ count }} carpool</strong> using this destination. <strong>The carpool will be deleted if you delete this destination</strong>.
+    {% else %}
+    There are <strong>{{ count }} carpools</strong> using this destination. <strong>The carpools will be deleted if you delete this destination</strong>.
+    {% endif %}
+    <ul>
+        {% for carpool in dest.carpools %}
+        <li><a href="{{ url_for('carpool.details', uuid=carpool.uuid) }}">{{ carpool.from_place }} to {{ carpool.to_place }}</a></li>
+        {% endfor %}
+    </ul>
+</p>
+
+<p>
     Really delete destination <strong>{{ dest.name }}</strong>?
 </p>
 


### PR DESCRIPTION
Related to https://github.com/RagtagOpen/nomad/issues/187
Fixes https://sentry.io/ragtag/carpools/issues/358596348/

This adjusts the destination delete admin page to give a warning when there are carpools connected to the destination that's about to be deleted. When the user confirms, it will delete the destination **and the carpools associated with it**.

This may or may not be what we want. We could also make the admin delete or otherwise disassociate the carpools from the destination before allowing the delete.