### PR TITLE
don't allow approving more riders than seats

### DIFF
--- a/app/carpool/views.py
+++ b/app/carpool/views.py
@@ -279,7 +279,9 @@ def modify_ride_request(carpool_uuid, request_uuid, action):
             if not user_is_driver:
                 flash("That's not your carpool", 'error')
                 return redirect(url_for('carpool.details', uuid=carpool.uuid))
-
+            if not request.carpool.seats_available:
+                flash("No seats available", 'error')
+                return redirect(url_for('carpool.details', uuid=carpool.uuid))
             request.status = 'approved'
             db.session.add(request)
             db.session.commit()

--- a/app/templates/carpools/show.html
+++ b/app/templates/carpools/show.html
@@ -48,6 +48,13 @@
             <div class="two-col-layout">
                 <div class="two-col-column">
                     <p>You're the driver of this carpool!</p>
+                    {% if not pool.seats_available %}
+                        <p>Your carpool is full.
+                        {% if pool.get_ride_requests_query(['requested']).count() %}
+                            Please let people awaiting your response know that they should find another carpool.
+                        {% endif %}
+                    </p>
+                    {% endif %}
                 </div>
                 <div class="two-col-column">
                     <a class="btn btn-danger" href="{{ url_for('carpool.cancel', uuid=pool.uuid) }}">Cancel your carpool</a>
@@ -58,7 +65,6 @@
                 <h4>Driver's Corner: Passenger Requests</h4>
 
                 <ul>
-
                 {% for request in pool.get_ride_requests_query() %}
 
                     <li><strong>{{ request.person.name }}</strong>
@@ -67,10 +73,12 @@
                         <br>
                     {%- if request.status == 'requested' %}
                         (Waiting for your response:&nbsp;
+                        {% if pool.seats_available %}
                         <a href="{{ url_for('carpool.modify_ride_request',
                                             action='approve',
                                             carpool_uuid=pool.uuid,
                                             request_uuid=request.uuid) }}">Approve</a>,&nbsp;
+                        {% endif %}
                         <a class="destructive" href="{{ url_for('carpool.modify_ride_request',
                                             action='deny',
                                             carpool_uuid=pool.uuid,


### PR DESCRIPTION
on driver's view of carpool page, if carpool is full:
- hide approve link
- show carpool is full message
- ask driver to respond to waiting users

on server side, reject approve if carpool is full

fixes https://github.com/RagtagOpen/nomad/issues/203