### PR TITLE
Add margin to primary buttons

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -92,6 +92,7 @@ input[type=submit]:focus, textarea:focus {
 input[type=submit].primary {
 	background-color: rgb(0,168,225);
 	color: white;
+	margin-bottom: 8px;
 }
 input[type=submit].secondary {
 	background-color: rgba(0,168,225,0);


### PR DESCRIPTION
Adds a bottom margin to primary buttons as a quick fix for them stacking weirdly on one another in mobile layouts; fixes #323 