### PR TITLE
Remove gender self-describe validation

### DIFF
--- a/app/auth/forms.py
+++ b/app/auth/forms.py
@@ -73,12 +73,7 @@ class ProfileForm(FlaskForm):
         ]
     )
     gender_self_describe = StringField(
-        "Gender",
-        [
-            Optional(),
-            Length(3, 80,
-                   "Please enter a name between 3 and 80 characters long"),
-        ]
+        "Gender"
     )
     submit = SubmitField(u'Update Your Profile')
 


### PR DESCRIPTION
Fixes #373 

The self-describe gender text box had a minimum length on it and the validation wasn't shown anywhere.