### PR TITLE
Update the delete template to make deleting work (Fixes #384)

### DIFF
--- a/app/templates/profiles/delete.html
+++ b/app/templates/profiles/delete.html
@@ -6,15 +6,18 @@
 
 	<div class="fullscreen">
 		<div class="interstitial-page">
+			<form method="post" class="form-page">
+			{{ form.hidden_tag() }}
 			<h1>Are you sure you want to permanently delete your account?</h1>
 			<p>This action cannot be undone. You will be removed from all carpools and you will stop receiving further emails.</p>
 			<br>
 			<p>If you are sure you want to delete your account, type your name exactly as found on your profile and confirm below.</p>
 			<br>
-			<input type="text" name="delete-name" id="delete-name">
+			{{ form.name(id='name') }}
 			<br><br>
-			<input class="secondary" type="submit" value="Cancel and go back">
 			<input class="destructive" type="submit" value="Delete my account">
+			<a class="secondary" href="{{ url_for('auth.profile') }}">Cancel and go back</a>
+			</form>
 		</div>
 	</div>
 

--- a/app/templates/profiles/delete.html
+++ b/app/templates/profiles/delete.html
@@ -13,7 +13,7 @@
 			<br>
 			<p>If you are sure you want to delete your account, type your name exactly as found on your profile and confirm below.</p>
 			<br>
-			{{ form.name(id='name') }}
+			{{ form.name(id='delete-name') }}
 			<br><br>
 			<input class="destructive" type="submit" value="Delete my account">
 			<a class="secondary" href="{{ url_for('auth.profile') }}">Cancel and go back</a>


### PR DESCRIPTION
This should make account deletion work. The view was fine as-is, but the template wasn't connecting to the form correctly.

Tested on my own machine, creating an account through google then deleting it.

Fixes #384.