### PR TITLE
Adjust padding so navbar buttons don't overlap.

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -259,7 +259,7 @@ select:focus {
 	    -ms-flex: 1 0 auto;
 	        flex: 1 0 auto;
 	display: inline-block;
-	padding-right: 40px;
+	padding-right: 25px;
 	height: 70px;
     padding-top: 21px;
 }


### PR DESCRIPTION
This fixes #312, by making it so that each button is less-wide, and therefore
the breakpoint triggers before the "Find a ride" button crashes into the
search bar.

There's still breathing room between the buttons, and it looks great on my mac running chrome.