### PR TITLE
Remove datefield format for now

### DIFF
--- a/app/carpool/forms.py
+++ b/app/carpool/forms.py
@@ -44,10 +44,10 @@ class DriverForm(FlaskForm):
     departure_lat = HiddenField()
     departure_lon = HiddenField()
 
-    departure_date = DateField(format='%m/%d/%Y')
+    departure_date = DateField()
     departure_hour = SelectField(choices=time_select_tuples(), default='9')
 
-    return_date = DateField(format='%m/%d/%Y')
+    return_date = DateField()
     return_hour = SelectField(choices=time_select_tuples(), default='9')
 
     vehicle_description = StringField()


### PR DESCRIPTION
Fixes #410.

Will have to re-look at the Firefox side of this.