### PR TITLE
Make a start at admin stats for Nomad

### DIFF
--- a/app/admin/views.py
+++ b/app/admin/views.py
@@ -40,6 +40,20 @@ def admin_index():
     )
 
 
+@admin_bp.route('/admin/stats/')
+@login_required
+@roles_required('admin')
+def admin_stats():
+    return render_template(
+        'admin/stats.html',
+        carpool_count=Carpool.query.count(),
+        ride_request_count_approved=RideRequest.query.filter_by(status='approved').count(),
+        ride_request_count_requested=RideRequest.query.filter_by(status='requested').count(),
+        destination_count=Destination.query.count(),
+        driver_count=Carpool.query.distinct(Carpool.driver_id).count(),
+    )
+
+
 @admin_bp.route('/admin/users/<uuid>')
 @login_required
 @roles_required('admin')

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -4,7 +4,7 @@
 {% block site %}
 <div class="content">
     <div class="fullscreen">
-    <h4>Admin</h4>
+    <h4>Admin <a href="{{ url_for('admin.admin_stats')}}">Stats</a></h4>
 
 <h3>Users</h3>
 

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -4,7 +4,7 @@
 {% block site %}
 <div class="content">
     <div class="fullscreen">
-    <h4>Admin <a href="{{ url_for('admin.admin_stats')}}">Stats</a></h4>
+    <h4>Admin</h4>
 
 <h3>Users</h3>
 

--- a/app/templates/admin/stats.html
+++ b/app/templates/admin/stats.html
@@ -1,0 +1,14 @@
+{%- extends "_template.html" %}
+{%- import "bootstrap/wtf.html" as wtf %}
+
+{% block site %}
+<div class="content">
+    <div class="fullscreen">
+        <h4><a href="{{ url_for('admin.admin_index')}}">Admin</a> Stats</h4>
+
+        <p class="lead">Nomad has matched <span class="badge">{{ ride_request_count_approved }}</span> riders with <span class="badge">{{ carpool_count }}</span> carpools driven by <span class="badge">{{ driver_count }}</span> volunteers traveling to <span class="badge">{{ destination_count }}</span> destinations.</p>
+        <p class="lead"><span class="badge">{{ ride_request_count_requested }}</span> riders are currently waiting for a ride.</p>
+
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/admin/stats.html
+++ b/app/templates/admin/stats.html
@@ -4,7 +4,9 @@
 {% block site %}
 <div class="content">
     <div class="fullscreen">
-        <h4><a href="{{ url_for('admin.admin_index')}}">Admin</a> Stats</h4>
+        <h4><a href="{{ url_for('admin.admin_index')}}">Admin</a>&nbsp;&raquo;&nbsp;
+            Stats
+        </h4>
 
         <p class="lead">Nomad has matched <span class="badge">{{ ride_request_count_approved }}</span> riders with <span class="badge">{{ carpool_count }}</span> carpools driven by <span class="badge">{{ driver_count }}</span> volunteers traveling to <span class="badge">{{ destination_count }}</span> destinations.</p>
         <p class="lead"><span class="badge">{{ ride_request_count_requested }}</span> riders are currently waiting for a ride.</p>


### PR DESCRIPTION
Since the ticket didn't give a solid mapping on these stats to an output format,
I figured that a stats page admins could refresh and look at would be helpful.

Starts working on #91 

<img width="1280" alt="screen shot 2017-10-15 at 1 26 44 pm" src="https://user-images.githubusercontent.com/710999/31588828-88eebd06-b1ac-11e7-80dc-7f19eed81684.png">
