### PR TITLE
Display address associated with destination in carpool details

### DIFF
--- a/app/templates/carpools/mine.html
+++ b/app/templates/carpools/mine.html
@@ -35,7 +35,10 @@
 
                     <p>Departs: {{ pool.leave_time | humanize }}</p>
                     <p>Returns: {{ pool.return_time | humanize }}</p>
-                    <p>Destination: {{ pool.destination.name }}</p>
+                    <p>Destination name: {{ pool.destination.name }}</p>
+                    {% if pool.current_user_is_driver or current_user_ride_request and current_user_ride_request.status == 'approved' %}
+                    <p>Destination address: {{ pool.destination.address }}</p>
+                    {%- endif %}
                 </div>
             </div>
 {% else %}

--- a/app/templates/carpools/show.html
+++ b/app/templates/carpools/show.html
@@ -20,7 +20,12 @@
             {% set current_user_ride_request = pool.get_current_user_ride_request() %}
 
             <h4>Carpool Details</h4>
-            <h1>{{ pool.from_place }} to {{ pool.destination.name }}</h1>
+            <p><b>pickup</b>: {{ pool.from_place }}</p>
+            <p><b>destination name</b>: {{ pool.destination.name }}</p>
+            {% if pool.current_user_is_driver or current_user_ride_request and current_user_ride_request.status == 'approved' %}
+            <p><b>destination address</b>: {{ pool.destination.address }}</p>
+            {%- endif %}
+
 
             <h4>Carpool Status</h4>
 

--- a/app/templates/email/driver_reminder.html
+++ b/app/templates/email/driver_reminder.html
@@ -3,7 +3,12 @@
 {% block content %}
 <p>Hi {{ carpool.driver.name }}!</p>
 
-<p>Thank you for carpooling to canvass at {{ carpool.destination.name }}. Your carpool's departure time is {{ carpool.leave_time | humanize }}, only two days away!</p>
+<p>Thank you for carpooling to canvass</p>
+<p>Pickup: {{ carpool.from_place }}</p>
+<p>Destination Name: {{ carpool.destination.name }}</p>
+<p>Destination Address: {{ carpool.destination.address }}</p>
+
+<p>Your carpool's departure time is {{ carpool.leave_time | humanize }}, only two days away!</p>
 
 <p>As the driver, it's your responsibility to coordinate with your riders. Make sure you have spoken with them to confirm their rides and settle all the details of pickup and drop-off. Your passengers are:</p>
 

--- a/app/templates/email/driver_reminder.txt
+++ b/app/templates/email/driver_reminder.txt
@@ -1,6 +1,11 @@
 Hi {{ carpool.driver.name }}!
 
-Thank you for carpooling to canvass at {{ carpool.destination.name }}. Your carpool's departure time is {{ carpool.leave_time | humanize }}, only two days away!
+Thank you for carpooling to canvass
+Pickup: {{ carpool.from_place }}
+Destination Name: {{ carpool.destination.name }}
+Destination Address: {{ carpool.destination.address }}
+
+Your carpool's departure time is {{ carpool.leave_time | humanize }}, only two days away!
 
 As the driver, it's your responsibility to coordinate with your riders. Make sure you have spoken with them to confirm their rides and settle all the details of pickup and drop-off. Your passengers are:
 {% for rider in carpool.riders %}

--- a/app/templates/email/ride_approved.html
+++ b/app/templates/email/ride_approved.html
@@ -3,7 +3,11 @@
 {% block content %}
 <p>Hi {{ rider.name }},</p>
 
-<p>Good news! {{ carpool.driver.name }} approved your request to join the carpool from {{ carpool.from_place }} to {{ carpool.destination.name }}, departing at {{ carpool.leave_time | humanize }}.</p>
+<p>Good news! {{ carpool.driver.name }} approved your request to join the carpool</p>
+<p>pickup: {{ carpool.from_place }}</p>
+<p>destination name: {{ carpool.destination.name }}</p>
+<p>destination address: {{ carpool.destination.address }}</p>
+<p>departing at: {{ carpool.leave_time | humanize }}</p>
 
 <p>Please contact {{ carpool.driver.name }} at {{ carpool.driver.email }} or {{ carpool.driver.phone_number }} ({{ carpool.driver.preferred_contact_method }} preferred) to figure out exactly when and where to meet.</p>
 

--- a/app/templates/email/ride_approved.txt
+++ b/app/templates/email/ride_approved.txt
@@ -1,6 +1,10 @@
 Hi {{ rider.name }},
 
-Good news! {{ carpool.driver.name }} approved your request to join the carpool from {{ carpool.from_place }} to {{ carpool.destination.name }}, departing at {{ carpool.leave_time | humanize }}.
+Good news! {{ carpool.driver.name }} approved your request to join the carpool
+pickup: {{ carpool.from_place }}
+destination name: {{ carpool.destination.name }}
+destination address: {{ carpool.destination.address }}
+departing at: {{ carpool.leave_time | humanize }}
 
 Please contact {{ carpool.driver.name }} at {{ carpool.driver.email }} or {{ carpool.driver.phone_number }} ({{ carpool.driver.preferred_contact_method }} preferred) to figure out exactly when and where to meet.
 

--- a/app/templates/email/rider_reminder.html
+++ b/app/templates/email/rider_reminder.html
@@ -3,7 +3,12 @@
 {% block content %}
 <p>Hi {{ rider.name }}!</p>
 
-<p>Thank you for carpooling to canvass at {{ carpool.destination.name }}. Your carpool's departure time is
+<p>Thank you for carpooling to canvass</p>
+<p>Pickup: {{ carpool.from_place }}</p>
+<p>Destination Name: {{ carpool.destination.name }}</p>
+<p>Destination Address: {{ carpool.destination.address }}</p>
+
+<p> Your carpool's departure time is
   {{ carpool.leave_time | humanize }}, only two days away!</p>
 
 <p>Make sure you have spoken to your driver {{ carpool.driver.name }} to confirm your ride and settle all the details of pickup and drop-off. Your driver's email is {{ carpool.driver.email }} and their phone number is {{ carpool.driver.phone_number }} ({{ carpool.driver.preferred_contact_method }} preferred).</p>

--- a/app/templates/email/rider_reminder.txt
+++ b/app/templates/email/rider_reminder.txt
@@ -1,6 +1,11 @@
 Hi {{ rider.name }}!
 
-Thank you for carpooling to canvass at {{ carpool.destination.name }}. Your carpool's departure time is {{ carpool.leave_time | humanize }}, only two days away!
+Thank you for carpooling to canvass
+Pickup: {{ carpool.from_place }}
+Destination Name: {{ carpool.destination.name }}
+Destination Address: {{ carpool.destination.address }}
+
+Your carpool's departure time is {{ carpool.leave_time | humanize }}, only two days away!
 
 Make sure you have spoken to your driver {{ carpool.driver.name }} to confirm your ride and settle all the details of pickup and drop-off. Your driver's email is {{ carpool.driver.email }} and their phone number is {{ carpool.driver.phone_number }} ({{ carpool.driver.preferred_contact_method }} preferred).
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -32,6 +32,7 @@ class PersonFactory(BaseFactory):
 class DestinationFactory(BaseFactory):
     """Carpool factory."""
     name = Sequence(lambda n: 'dest{0}'.format(n))
+    address = Sequence(lambda n: '123 fake street'.format(n))
 
     class Meta:
         """Factory configuration."""

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -58,7 +58,10 @@ class TestEmailTemplates:
             carpool=carpool,
             rider=rider,
         )
-        assert 'approved your request to join the carpool from from to dest' in rendered
+        assert 'approved your request to join the carpool' in rendered
+        assert 'pickup: from' in rendered
+        assert 'destination name: dest' in rendered
+        assert 'destination address: 123 fake street' in rendered
 
     def test_ride_denied(self, db):
         rider = PersonFactory()


### PR DESCRIPTION
@flynnwastaken this fixes #471 let me know what you think of the approach:
- included destination address in carpool details for approved riders and drivers
- included destination address in my carpools view for approved riders and drivers
- included destination address in rider reminder, driver reminder, and rider approved emails