### PR TITLE
Use near_radius filter when returning carpools

### DIFF
--- a/app/carpool/views.py
+++ b/app/carpool/views.py
@@ -102,7 +102,7 @@ def start_geojson():
             # The conversion factor here is based on a 40deg latitude
             # (roughly around Virginia)
             radius_degrees = near_radius / 111034.61
-            pools.filter(
+            pools = pools.filter(
                 func.ST_Distance(Carpool.from_point, center) <= radius_degrees
             )
 


### PR DESCRIPTION
This should fix #415 the problem there, I believe, was that the carpools filter was not actually making use of the near radius filter. Thus, we were returning too many destinations and the map was zooming way out to include them all. With this change, we are only returning relevant destinations and the map is properly zoomed.