### PR TITLE
admin cancel ride on carpool detail page

### DIFF
--- a/app/admin/forms.py
+++ b/app/admin/forms.py
@@ -54,3 +54,13 @@ class DeleteDestinationForm(FlaskForm):
 class ProfilePurgeForm(FlaskForm):
     cancel = SubmitField("Nevermind, Go Back")
     submit = SubmitField("Permanently Delete Their Profile")
+
+
+class CancelCarpoolAdminForm(FlaskForm):
+    reason = StringField(
+        "Reason",
+        description="Describe why you're canceling this carpool. "
+                    "This will be visible to allriders."
+    )
+    cancel = SubmitField("Never Mind, Go Back")
+    submit = SubmitField("Cancel This Ride")

--- a/app/admin/forms.py
+++ b/app/admin/forms.py
@@ -60,7 +60,7 @@ class CancelCarpoolAdminForm(FlaskForm):
     reason = StringField(
         "Reason",
         description="Describe why you're canceling this carpool. "
-                    "This will be visible to allriders."
+                    "This will be visible to all riders."
     )
     cancel = SubmitField("Never Mind, Go Back")
     submit = SubmitField("Cancel This Ride")

--- a/app/admin/views.py
+++ b/app/admin/views.py
@@ -12,6 +12,7 @@ from flask import (
 from flask_login import current_user, login_required
 from . import admin_bp
 from .forms import (
+    CancelCarpoolAdminForm,
     DeleteDestinationForm,
     DestinationForm,
     ProfilePurgeForm,
@@ -442,3 +443,24 @@ def email_preview(template):
     html = render_template('email/{}.html'.format(template), **data)
 
     return render_template('admin/emailpreview.html', template=template, text=text, html=html)
+
+
+@admin_bp.route('/admin/<uuid>/cancel', methods=['GET', 'POST'])
+@login_required
+@roles_required('admin')
+def admin_cancel_carpool(uuid):
+    carpool = Carpool.uuid_or_404(uuid)
+
+    cancel_form = CancelCarpoolAdminForm()
+    if cancel_form.validate_on_submit():
+        if cancel_form.submit.data:
+            cancel_carpool(carpool, cancel_form.reason.data, notify_driver=True)
+
+            flash('The carpool was cancelled', 'success')
+
+            # TODO: redirect to carpool list page when available
+            return redirect(url_for('admin.admin_index'))
+
+        return redirect(url_for('carpool.details', uuid=carpool.uuid))
+
+    return render_template('carpools/cancel.html', form=cancel_form)

--- a/app/carpool/views.py
+++ b/app/carpool/views.py
@@ -480,17 +480,15 @@ def cancel(uuid):
     return render_template('carpools/cancel.html', form=cancel_form)
 
 
-def cancel_carpool(carpool, reason=None):
-    _email_carpool_cancelled(carpool, reason)
+def cancel_carpool(carpool, reason=None, notify_driver=False):
+    _email_carpool_cancelled(carpool, reason, notify_driver)
     db.session.delete(carpool)
     db.session.commit()
 
 
-def _email_carpool_cancelled(carpool, reason):
+def _email_carpool_cancelled(carpool, reason, notify_driver):
     driver = carpool.driver
     riders = carpool.riders_and_potential_riders
-    if not riders:
-        return
 
     if not reason:
         reason = '<reason not given>'
@@ -507,6 +505,17 @@ def _email_carpool_cancelled(carpool, reason):
             rider=rider,
             carpool=carpool,
             reason=reason,
+        )
+
+    if notify_driver:
+        send_email(
+            'carpool_cancelled',
+            driver.email,
+            subject,
+            driver=driver,
+            carpool=carpool,
+            reason=reason,
+            is_driver=True
         )
 
 

--- a/app/templates/carpools/cancel.html
+++ b/app/templates/carpools/cancel.html
@@ -7,13 +7,13 @@
     <div class="fullscreen">
       <div class="interstitial-page">
         <h1>Are you sure you want to cancel this carpool?</h1>
-        <p>Your passengers will be notified.</p>
+        <p>All passengers will be notified.</p>
 
         <form method="post" class="form-page">
             {{ form.hidden_tag() }}
 
             <h4>Why are you canceling?</h4>
-            <h5>(This reason will be shared with your passengers.)</h5>
+            <h5>(This reason will be shared with the passengers.)</h5>
             <p>{{ form.reason() }}</p>
 
             <p>

--- a/app/templates/carpools/show.html
+++ b/app/templates/carpools/show.html
@@ -55,21 +55,29 @@
                 </div>
             </div>
 
-        {% elif pool.current_user_is_driver %}
+        {% elif pool.current_user_is_driver or current_user.has_roles('admin') %}
             <div class="two-col-layout">
                 <div class="two-col-column">
-                    <p>You're the driver of this carpool!</p>
-                    {% if not pool.seats_available %}
-                        <p>Your carpool is full.
-                        {% if pool.get_ride_requests_query(['requested']).count() %}
-                            Please let people awaiting your response know that they should find another carpool.
+                    {% if pool.current_user_is_driver %}
+                        <p>You're the driver of this carpool!</p>
+                        {% if not pool.seats_available %}
+                            <p>Your carpool is full.
+                            {% if pool.get_ride_requests_query(['requested']).count() %}
+                                Please let people awaiting your response know that they should find another carpool.
+                            {% endif %}
+                        </p>
                         {% endif %}
-                    </p>
+                    {% else %}
+                        {{pool.riders|length}} confirmed passengers
                     {% endif %}
                 </div>
                 <div class="two-col-column">
-                    <a class="btn btn-danger" href="{{ url_for('carpool.cancel', uuid=pool.uuid) }}">Cancel your carpool</a>
-                    <a class="btn btn-primary" href="{{ url_for('carpool.edit', uuid=pool.uuid) }}">Edit your carpool</a>
+                    {% if pool.current_user_is_driver %}
+                        <a class="btn btn-danger" href="{{ url_for('carpool.cancel', uuid=pool.uuid) }}">Cancel this carpool</a>
+                        <a class="btn btn-primary" href="{{ url_for('carpool.edit', uuid=pool.uuid) }}">Edit your carpool</a>
+                    {% else %}
+                        <a class="btn btn-danger" href="{{ url_for('admin.admin_cancel_carpool', uuid=pool.uuid) }}">Cancel this carpool</a>
+                    {% endif %}
                 </div>
             </div>
 

--- a/app/templates/email/carpool_cancelled.html
+++ b/app/templates/email/carpool_cancelled.html
@@ -6,15 +6,15 @@
 <p>Unfortunately, the carpool from {{ carpool.from_place }} to {{ carpool.destination.name }} at {{ carpool.leave_time | humanize }} has been cancelled.</p>
 
 {% if is_driver %}
+    <p>This carpool was cancelled by an administrator.</p>
+
+    <p>The administrator gave the following reason for cancelling: {{ reason }}.</p>
+{% else %}
     <p>The driver gave the following reason for cancelling: {{ reason }}.</p>
 
     <p>You can ask them at {{ driver.email }} or {{ driver.phone_number }} ({{ driver.preferred_contact_method }} preferred) if they're willing to reschedule, or go to {{ url_for('carpool.find', _external=True) }} to look for another ride.</p>
 
     <p>Thank you for your enthusiasm!</p>
-{% else %}
-    <p>This carpool was cancelled by an administrator.</p>
-
-    <p>The administrator gave the following reason for cancelling: {{ reason }}.</p>
 {% endif %}
 
 <p>Swing Left &amp; the Nomad team</p>

--- a/app/templates/email/carpool_cancelled.html
+++ b/app/templates/email/carpool_cancelled.html
@@ -5,11 +5,17 @@
 
 <p>Unfortunately, the carpool from {{ carpool.from_place }} to {{ carpool.destination.name }} at {{ carpool.leave_time | humanize }} has been cancelled.</p>
 
-<p>The driver gave the following reason for cancelling: {{ reason }}.</p>
+{% if is_driver %}
+    <p>The driver gave the following reason for cancelling: {{ reason }}.</p>
 
-<p>You can ask them at {{ driver.email }} or {{ driver.phone_number }} ({{ driver.preferred_contact_method }} preferred) if they're willing to reschedule, or go to {{ url_for('carpool.find', _external=True) }} to look for another ride.</p>
+    <p>You can ask them at {{ driver.email }} or {{ driver.phone_number }} ({{ driver.preferred_contact_method }} preferred) if they're willing to reschedule, or go to {{ url_for('carpool.find', _external=True) }} to look for another ride.</p>
 
-<p>Thank you for your enthusiasm!</p>
+    <p>Thank you for your enthusiasm!</p>
+{% else %}
+    <p>This carpool was cancelled by an administrator.</p>
+
+    <p>The administrator gave the following reason for cancelling: {{ reason }}.</p>
+{% endif %}
 
 <p>Swing Left &amp; the Nomad team</p>
 {% endblock %}

--- a/app/templates/email/carpool_cancelled.txt
+++ b/app/templates/email/carpool_cancelled.txt
@@ -2,13 +2,14 @@ Hello {{ rider.name }},
 
 Unfortunately, the carpool from {{ carpool.from_place }} to {{ carpool.destination.name }} at {{ carpool.leave_time | humanize }} has been cancelled.
 {{% if is_driver %}}
-The driver gave the following reason for cancelling: {{ reason }}.
 
-You can ask them at {{ driver.email }} or {{ driver.phone_number }} ({{ driver.preferred_contact_method }} preferred) if they're willing to reschedule, or go to {% else %}
 This carpool was cancelled by an administrator.
 
 The administrator gave the following reason for cancelling: {{ reason }}.
-{{url_for('carpool.find', _external=True) }} to look for another ride.
+{% else %}
+The driver gave the following reason for cancelling: {{ reason }}.
+
+You can ask them at {{ driver.email }} or {{ driver.phone_number }} ({{ driver.preferred_contact_method }} preferred) if they're willing to reschedule, or go to {{ url_for('carpool.find', _external=True) }} to look for another ride.
 {% endif %}
 Thank you for your enthusiasm!
 

--- a/app/templates/email/carpool_cancelled.txt
+++ b/app/templates/email/carpool_cancelled.txt
@@ -1,11 +1,15 @@
 Hello {{ rider.name }},
 
 Unfortunately, the carpool from {{ carpool.from_place }} to {{ carpool.destination.name }} at {{ carpool.leave_time | humanize }} has been cancelled.
-
+{{% if is_driver %}}
 The driver gave the following reason for cancelling: {{ reason }}.
 
-You can ask them at {{ driver.email }} or {{ driver.phone_number }} ({{ driver.preferred_contact_method }} preferred) if they're willing to reschedule, or go to {{url_for('carpool.find', _external=True) }} to look for another ride.
+You can ask them at {{ driver.email }} or {{ driver.phone_number }} ({{ driver.preferred_contact_method }} preferred) if they're willing to reschedule, or go to {% else %}
+This carpool was cancelled by an administrator.
 
+The administrator gave the following reason for cancelling: {{ reason }}.
+{{url_for('carpool.find', _external=True) }} to look for another ride.
+{% endif %}
 Thank you for your enthusiasm!
 
 Swing Left & the Nomad team


### PR DESCRIPTION
fixes https://github.com/RagtagOpen/nomad/issues/500

- show cancel carpool button to carpool detail page if logged in as admin
- add admin version of form with different submit button text: Cancel This Ride"
- email driver when admin cancels carpool
- add tests for email rendering