### PR TITLE
#487 - Carpool dates test

### DIFF
--- a/app/carpool/forms.py
+++ b/app/carpool/forms.py
@@ -113,7 +113,7 @@ class DriverForm(FlaskForm):
                 "Your return date should be after your departure date.")
             result = False
 
-        if (self.departure_datetime <= datetime.datetime.now()) or (self.return_datetime < datetime.datetime.today());
+        if (self.departure_datetime <= datetime.datetime.now()) or (self.return_datetime < datetime.datetime.today()):
             self.departure_date.errors.append(
                 "Your carpool cannot happen in the past")
             result = False

--- a/app/carpool/forms.py
+++ b/app/carpool/forms.py
@@ -101,13 +101,6 @@ class DriverForm(FlaskForm):
             int(self.return_hour.data)
         )
 
-        # Departure and return scheduling rules
-
-	# - Not departing or returning in the past
-        # - Not departing after return
-        # - Not exceeding TRIP_MAX_LENGTH_DAYS
-        # - Not happening after TRIP_MAX_DAYS_IN_FUTURE    
-
         if self.departure_datetime >= self.return_datetime:
             self.departure_date.errors.append(
                 "Your return date should be after your departure date.")

--- a/app/carpool/forms.py
+++ b/app/carpool/forms.py
@@ -101,14 +101,21 @@ class DriverForm(FlaskForm):
             int(self.return_hour.data)
         )
 
+        # Departure and return scheduling rules
+
+	# - Not departing or returning in the past
+        # - Not departing after return
+        # - Not exceeding TRIP_MAX_LENGTH_DAYS
+        # - Not happening after TRIP_MAX_DAYS_IN_FUTURE    
+
         if self.departure_datetime >= self.return_datetime:
             self.departure_date.errors.append(
                 "Your return date should be after your departure date.")
             result = False
 
-        if self.return_datetime < datetime.datetime.today():
-            self.return_date.errors.append(
-                "Your carpool cannot happen in the past.")
+        if (self.departure_datetime <= datetime.datetime.now()) or (self.return_datetime < datetime.datetime.today());
+            self.departure_date.errors.append(
+                "Your carpool cannot happen in the past")
             result = False
 
         delta = self.return_datetime - self.departure_datetime


### PR DESCRIPTION
Removing the possibility of creating carpools with departures or returns in the past. Fixes #487 