### PR TITLE
Update gitignore and Dockerfile to work with Pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *.sqlite
 .python-version
+.pytest_cache
 
 # Jetbrains IDEs
 .idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install -U --no-cache-dir pipenv
 
 ADD Pipfile .
 ADD Pipfile.lock .
-RUN pipenv install --system --deploy
+RUN pipenv install --system --deploy --dev
 
 ADD . .
 


### PR DESCRIPTION
Hello again @iandees and @jillh510!

`pytest` did not appear to be installed in the Docker container, making running `docker-compose run nomad pytest` fail.  I've added the `--dev` flag to the pipenv command, which solves the problem - but there may well be a better way.

`pytest` also creates a `.pytest_cache` folder, which I've added to the .gitignore.

LMK what you think!