### PR TITLE
Refactor integration testing to allow for better login flow testing

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -6,7 +6,7 @@ from factory import Sequence, SubFactory, LazyFunction
 from factory.alchemy import SQLAlchemyModelFactory
 
 from app import db
-from app.models import Person, Carpool, Destination, RideRequest
+from app.models import Person, Carpool, Destination, RideRequest, Role
 
 
 class BaseFactory(SQLAlchemyModelFactory):
@@ -27,6 +27,15 @@ class PersonFactory(BaseFactory):
     class Meta:
         """Factory configuration."""
         model = Person
+
+class RoleFactory(BaseFactory):
+    """Role factory."""
+    name = Sequence(lambda n: 'Role{0}'.format(n))
+    description = "role description"
+
+    class Meta:
+        """Factory configuration."""
+        model = Role
 
 
 class DestinationFactory(BaseFactory):

--- a/tests/test_email_templates.py
+++ b/tests/test_email_templates.py
@@ -1,0 +1,134 @@
+import pytest
+from .factories import PersonFactory, CarpoolFactory, RideRequestFactory, DestinationFactory
+from flask import render_template
+
+
+@pytest.mark.usefixtures('request_context')
+class TestEmailTemplates:
+    def test_ride_requested(self, db):
+        rider = PersonFactory()
+        carpool = CarpoolFactory(from_place='from')
+        db.session.add(rider)
+        db.session.add(carpool)
+        db.session.commit()
+        rendered = render_template(
+            'email/ride_requested.html',
+            carpool=carpool,
+            rider=rider,
+        )
+        assert 'requested a ride in your carpool from from to dest' in rendered
+
+    def test_ride_approved(self, db):
+        rider = PersonFactory()
+        carpool = CarpoolFactory(from_place='from')
+        db.session.add(rider)
+        db.session.add(carpool)
+        db.session.commit()
+        config = {
+            'BRANDING_LIABILITY_URL': 'liability.html',
+            'BRANDING_EMAIL_SIGNATURE': '-- Test Team',
+        }
+        rendered = render_template(
+            'email/ride_approved.html',
+            carpool=carpool,
+            rider=rider,
+            config=config,
+        )
+        assert 'approved your request to join the carpool' in rendered
+        assert 'Pickup: from' in rendered
+        assert 'Destination name: dest' in rendered
+        assert 'Destination address: 123 fake street' in rendered
+        for key in config:
+            assert config[key] in rendered
+
+    def test_ride_denied(self, db):
+        rider = PersonFactory()
+        carpool = CarpoolFactory(from_place='from')
+        db.session.add(rider)
+        db.session.add(carpool)
+        db.session.commit()
+        rendered = render_template(
+            'email/ride_denied.html',
+            carpool=carpool,
+            rider=rider,
+        )
+        assert 'declined your request to join the carpool from from to dest' in rendered
+
+    def test_email_signature(self, db):
+        templates = [
+            'admin_destination_deleted', 'admin_destination_modified',
+            'approved_ride_request_cancelled', 'carpool_cancelled', 'driver_reminder',
+            'ride_approved', 'ride_denied', 'ride_request_cancelled',
+            'ride_requested', 'rider_reminder']
+        config = {
+            'BRANDING_EMAIL_SIGNATURE': '-- Test Team',
+        }
+        rider = PersonFactory()
+        db.session.add(rider)
+        driver = PersonFactory()
+        db.session.add(driver)
+        carpool = CarpoolFactory(from_place='from')
+        db.session.add(carpool)
+        destination = DestinationFactory()
+        db.session.add(destination)
+        db.session.commit()
+        for ext in ['html', 'txt']:
+            for template in templates:
+                template_path = 'email/%s.%s' % (template, ext)
+                print(template_path)
+                rendered = render_template(
+                    template_path,
+                    config=config,
+                    carpool=carpool,
+                    rider=rider,
+                    driver=driver,
+                    person=rider,
+                    destination=destination,
+                )
+                assert config['BRANDING_EMAIL_SIGNATURE'] in rendered, \
+                    '%s missing signature' % template_path
+
+    def test_admin_cancelled(self, db):
+        driver = PersonFactory()
+        db.session.add(driver)
+        carpool = CarpoolFactory(from_place='from', driver=driver)
+        db.session.add(carpool)
+        rider = PersonFactory()
+        db.session.add(rider)
+        ride_request = RideRequestFactory(person=rider, carpool=carpool)
+        db.session.add(ride_request)
+        db.session.commit()
+        rendered = render_template(
+            'email/carpool_cancelled.html',
+            driver=driver,
+            rider=rider,
+            carpool=carpool,
+            is_driver=True,
+            reason='test_admin_cancelled',
+            person=driver,
+        )
+        assert 'carpool was cancelled by an administrator' in rendered
+        assert 'test_admin_cancelled' in rendered
+        assert 'driver gave the following reason' not in rendered
+
+    def test_driver_cancelled(self, db):
+        driver = PersonFactory()
+        db.session.add(driver)
+        carpool = CarpoolFactory(from_place='from', driver=driver)
+        db.session.add(carpool)
+        rider = PersonFactory()
+        db.session.add(rider)
+        ride_request = RideRequestFactory(person=rider, carpool=carpool)
+        db.session.add(ride_request)
+        db.session.commit()
+        rendered = render_template(
+            'email/carpool_cancelled.html',
+            driver=driver,
+            rider=rider,
+            carpool=carpool,
+            reason='test_driver_cancelled',
+            person=rider,
+        )
+        assert 'carpool was cancelled by an administrator' not in rendered
+        assert 'test_driver_cancelled' in rendered
+        assert 'driver gave the following reason' in rendered

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -4,8 +4,10 @@
 from werkzeug.datastructures import MultiDict
 
 from app.auth.forms import ProfileForm
+import pytest
 
 
+@pytest.mark.usefixtures('request_context')
 class TestProfileForm:
     """Profile form."""
     def test_validate_name_missing(self, person):

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -5,10 +5,31 @@ See: http://webtest.readthedocs.org/
 import urllib
 from http import HTTPStatus
 
-from flask import url_for, render_template
-import flask_login.utils
+from app.auth.oauth import OAuthSignIn
+from flask import request
 
 from .factories import PersonFactory, CarpoolFactory, DestinationFactory, RideRequestFactory
+
+# A Mock OAuth Provider. Allows for users to be logged in
+class MockSignIn(OAuthSignIn):
+    def __init__(self):
+        self.provider_name = 'mock'
+
+    def authorize(self):
+        pass
+
+    def callback(self):
+        return (
+            request.args.get('id'),
+            request.args.get('name'),
+            request.args.get('email'),
+        )
+
+def login(testapp, social_id, user_name, user_email):
+    testapp.get('/callback/mock', params=dict(id=social_id, name=user_name, email=user_email))
+
+def login_person(testapp, person):
+    login(testapp, person.social_id, person.name, person.email)
 
 
 class TestProfile:
@@ -16,11 +37,11 @@ class TestProfile:
         res = testapp.get('/profile')
         assert res.status_code == HTTPStatus.FOUND
         url = urllib.parse.urlparse(res.headers['Location'])
-        assert url.path == url_for('auth.login')
+        assert url.path == '/login'
         assert url.query == ''
 
-    def test_profile_logged_in(self, testapp, db, person, monkeypatch):
-        monkeypatch.setattr(flask_login.utils, '_get_user', lambda: person)
+    def test_profile_logged_in(self, testapp, db, person):
+        login_person(testapp, person)
         res = testapp.get('/profile')
         assert res.status_code == HTTPStatus.OK
         form = res.forms[1]
@@ -32,132 +53,13 @@ class TestProfile:
         assert person.gender == 'Female'
         assert person.preferred_contact_method == 'email'
 
-
-class TestEmailTemplates:
-    def test_ride_requested(self, db):
-        rider = PersonFactory()
-        carpool = CarpoolFactory(from_place='from')
-        db.session.add(rider)
-        db.session.add(carpool)
+    def test_profile_blocked_is_logged_out(self, testapp, db, person, blocked_role):
+        login_person(testapp, person)
+        person.roles.append(blocked_role)
+        print(person.is_active)
         db.session.commit()
-        rendered = render_template(
-            'email/ride_requested.html',
-            carpool=carpool,
-            rider=rider,
-        )
-        assert 'requested a ride in your carpool from from to dest' in rendered
-
-    def test_ride_approved(self, db):
-        rider = PersonFactory()
-        carpool = CarpoolFactory(from_place='from')
-        db.session.add(rider)
-        db.session.add(carpool)
-        db.session.commit()
-        config = {
-            'BRANDING_LIABILITY_URL': 'liability.html',
-            'BRANDING_EMAIL_SIGNATURE': '-- Test Team',
-        }
-        rendered = render_template(
-            'email/ride_approved.html',
-            carpool=carpool,
-            rider=rider,
-            config=config,
-        )
-        assert 'approved your request to join the carpool' in rendered
-        assert 'Pickup: from' in rendered
-        assert 'Destination name: dest' in rendered
-        assert 'Destination address: 123 fake street' in rendered
-        for key in config:
-            assert config[key] in rendered
-
-    def test_ride_denied(self, db):
-        rider = PersonFactory()
-        carpool = CarpoolFactory(from_place='from')
-        db.session.add(rider)
-        db.session.add(carpool)
-        db.session.commit()
-        rendered = render_template(
-            'email/ride_denied.html',
-            carpool=carpool,
-            rider=rider,
-        )
-        assert 'declined your request to join the carpool from from to dest' in rendered
-
-    def test_email_signature(self, db):
-        templates = [
-            'admin_destination_deleted', 'admin_destination_modified',
-            'approved_ride_request_cancelled', 'carpool_cancelled', 'driver_reminder',
-            'ride_approved', 'ride_denied', 'ride_request_cancelled',
-            'ride_requested', 'rider_reminder']
-        config = {
-            'BRANDING_EMAIL_SIGNATURE': '-- Test Team',
-        }
-        rider = PersonFactory()
-        db.session.add(rider)
-        driver = PersonFactory()
-        db.session.add(driver)
-        carpool = CarpoolFactory(from_place='from')
-        db.session.add(carpool)
-        destination = DestinationFactory()
-        db.session.add(destination)
-        db.session.commit()
-        for ext in ['html', 'txt']:
-            for template in templates:
-                template_path = 'email/%s.%s' % (template, ext)
-                print(template_path)
-                rendered = render_template(
-                    template_path,
-                    config=config,
-                    carpool=carpool,
-                    rider=rider,
-                    driver=driver,
-                    person=rider,
-                    destination=destination,
-                )
-                assert config['BRANDING_EMAIL_SIGNATURE'] in rendered, \
-                    '%s missing signature' % template_path
-
-    def test_admin_cancelled(self, db):
-        driver = PersonFactory()
-        db.session.add(driver)
-        carpool = CarpoolFactory(from_place='from', driver=driver)
-        db.session.add(carpool)
-        rider = PersonFactory()
-        db.session.add(rider)
-        ride_request = RideRequestFactory(person=rider, carpool=carpool)
-        db.session.add(ride_request)
-        db.session.commit()
-        rendered = render_template(
-            'email/carpool_cancelled.html',
-            driver=driver,
-            rider=rider,
-            carpool=carpool,
-            is_driver=True,
-            reason='test_admin_cancelled',
-            person=driver,
-        )
-        assert 'carpool was cancelled by an administrator' in rendered
-        assert 'test_admin_cancelled' in rendered
-        assert 'driver gave the following reason' not in rendered
-
-    def test_driver_cancelled(self, db):
-        driver = PersonFactory()
-        db.session.add(driver)
-        carpool = CarpoolFactory(from_place='from', driver=driver)
-        db.session.add(carpool)
-        rider = PersonFactory()
-        db.session.add(rider)
-        ride_request = RideRequestFactory(person=rider, carpool=carpool)
-        db.session.add(ride_request)
-        db.session.commit()
-        rendered = render_template(
-            'email/carpool_cancelled.html',
-            driver=driver,
-            rider=rider,
-            carpool=carpool,
-            reason='test_driver_cancelled',
-            person=rider,
-        )
-        assert 'carpool was cancelled by an administrator' not in rendered
-        assert 'test_driver_cancelled' in rendered
-        assert 'driver gave the following reason' in rendered
+        res = testapp.get('/profile')
+        assert res.status_code == HTTPStatus.FOUND
+        url = urllib.parse.urlparse(res.headers['Location'])
+        assert url.path == '/login'
+        assert url.query == ''

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -55,7 +55,7 @@ class TestPerson:
         assert person.has_roles('admin')
 
 
-@pytest.mark.usefixtures('db')
+@pytest.mark.usefixtures('db', 'request_context')
 class TestCarpool:
     """Carpool tests."""
 
@@ -117,7 +117,6 @@ class TestCarpool:
             '_get_user',
             lambda: ride_request_2.person,
         )
-
         assert carpool.get_current_user_ride_request() is ride_request_2
 
     def test_current_user_is_driver_not_logged_in(self):


### PR DESCRIPTION
A few overall changes: 

For integration tests, we probably don't want to be inside a request context, as we want to be able to test behavior across multiple requests from the outside.

Handling login testing through monkeypatching get_user was making it difficult to integration-test session lifecycle behavior. This mocks an oauth service (in a rather hacktastic way) which ensures that session lifecycles can be integration tested.

Separates the email-template tests from the web integration tests.