### PR TITLE
Use a custom anonymous user

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,7 @@
 import datetime
 import uuid
 from flask import abort
-from flask_login import UserMixin, current_user
+from flask_login import AnonymousUserMixin, UserMixin, current_user
 from geoalchemy2 import Geometry
 from geoalchemy2.shape import to_shape
 from shapely.geometry import mapping
@@ -72,6 +72,13 @@ class PersonRole(db.Model):
                            default=datetime.datetime.utcnow)
     person_id = db.Column(db.Integer, db.ForeignKey('people.id'))
     role_id = db.Column(db.Integer, db.ForeignKey('roles.id'))
+
+
+class AnonymousUser(AnonymousUserMixin):
+    def has_roles(self, *roles):
+        return False
+
+login_manager.anonymous_user = AnonymousUser
 
 
 class Person(UserMixin, db.Model, UuidMixin):


### PR DESCRIPTION
Fixes #551 
https://sentry.io/share/issue/19ea2dc1e3694a7b97eb8105387085d2/

In https://github.com/RagtagOpen/nomad/pull/540 we added a call to `current_user.has_roles()`, but when a user isn't logged in, `current_user` will be an [`AnonymousUserMixin`](https://flask-login.readthedocs.io/en/latest/#anonymous-users) that doesn't have the `has_roles()` method. To solve this, I added a custom anonymous user that does have the `has_roles()` that always returns false.