### PR TITLE
clarified "Rides Requested" includes approved and pending requests. (Issue 550)

### DIFF
--- a/app/templates/admin/carpool/list.html
+++ b/app/templates/admin/carpool/list.html
@@ -19,7 +19,7 @@
             <th>Driver Name</th>
             <th>Driver Email</th>
             <th>Max Riders</th>
-            <th>Ride Requests</th>
+            <th>All requests (pending and approved)</th>
             <th>Approved Riders</th>
             <th>Carpool Details Link</th>
         </tr>


### PR DESCRIPTION
Re https://github.com/RagtagOpen/nomad/issues/550

I used the suggested text from @jillh510 : "All requests (pending and approved)".  Maybe the label should be shortened.