### PR TITLE
first pass at redirecting new users to previous pages

### DIFF
--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -37,6 +37,7 @@ def get_redirect_target():
 
 @auth_bp.route('/login')
 def login():
+    session['login-referrer'] = request.referrer
     return render_template('auth/login.html')
 
 
@@ -83,8 +84,9 @@ def oauth_callback(provider):
         flash("Thanks for logging in! Please update your profile.", 'success')
         # Go to the profile now...
         next_url = url_for('auth.profile')
-        # ...and after they update their profile go to the index
-        session['next'] = url_for('carpool.index')
+        # ...and after they update their profile, go to the page that referred them here
+        session['next'] = session['login-referrer']
+        del session['login-referrer']
 
     if user.has_roles('blocked'):
         session.pop('next', None)


### PR DESCRIPTION
Hello @joearasin, @iandees, @jillh510, this is a first pass with no test at #482 – a join link.

We basically already have these, just by sending the user to `carpools/<carpool-id>`.  Thanks to Joe and Ian fixing the login redirect, this works for existing users who are not logged in.  This PR will make things work for new users.  

I've done this by adding a field to the session object.  I _think_ this is secure, but I am not certain.  What do y'all think / is there a better way to do this?