### PR TITLE
use standard bootstrap nav

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -163,7 +163,6 @@ select:focus {
 .logo {
 	width: 143px;
 	height: 50px;
-	margin: 10px 0;
 	background: url("../img/logo_ragtag.png") center / contain no-repeat;
 }
 button.navbar-toggle {
@@ -182,7 +181,7 @@ button.navbar-toggle {
 	padding: 0 10px 0 10px;
 }
 .navbar-nav li a {
-	line-height: 50px;
+	line-height: 30px;
 }
 
 /* ===== start privacy.html header ===== */

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -157,6 +157,36 @@ select:focus {
 	    -ms-flex-pack: justify;
 	        justify-content: space-between;
 }
+
+/* ===== NAVBAR ===== */
+
+.logo {
+	width: 143px;
+	height: 50px;
+	margin: 10px 0;
+	background: url("../img/logo_ragtag.png") center / contain no-repeat;
+}
+button.navbar-toggle {
+	margin-top: 20px;
+}
+#locationQuery {
+	min-width: 300px;
+	background: url("../img/ic_search_24px.svg") 7px center no-repeat;
+	text-indent: 25px;
+}
+.navbar>.container .navbar-brand, .navbar>.container-fluid .navbar-brand {
+	margin-left: 20px;
+	margin-right: 20px;
+}
+#ride-select-form span {
+	padding: 0 10px 0 10px;
+}
+.navbar-nav li a {
+	line-height: 50px;
+}
+
+/* ===== start privacy.html header ===== */
+/* remove if privacy.html is obsolete (ie subset terms.html) */
 .header-left {
 	-webkit-box-flex: 1;
 	    -ms-flex: 1 1 auto;
@@ -176,15 +206,6 @@ select:focus {
 	-webkit-box-flex: 0;
 	    -ms-flex: 0 1 auto;
 	        flex: 0 1 auto;
-}
-.header-left .logo {
-	width: 143px;
-	height: 50px;
-	margin: 10px 0;
-	background: url("../img/logo_ragtag.png") top left / contain no-repeat;
-}
-.header-left .logo.generic {
-	background: url("../img/logo_ragtag.png") top left / contain no-repeat;
 }
 
 .header-left .header-search-bar {
@@ -277,6 +298,9 @@ select:focus {
     margin-left: 5px;
     top: -1px;
 }
+
+/* ===== end privacy.html header ===== */
+
 .mobile-back-link {
 	position: fixed;
 	width: 70px;

--- a/app/static/css/swing-left.css
+++ b/app/static/css/swing-left.css
@@ -1,8 +1,5 @@
-.header-left .logo {
+.logo {
     width: 143px;
     height: 50px;
-    background: url("../img/logo-swingleft.png") top left / contain no-repeat;
-}
-.header-left .logo.generic {
-    background: url("../img/logo-swingleft.png") top left / contain no-repeat;
+    background: url("../img/logo-swingleft.png") center / contain no-repeat;
 }

--- a/app/templates/_template.html
+++ b/app/templates/_template.html
@@ -126,44 +126,48 @@ function doLogout() {
     </div>
 
     <div class="collapse navbar-collapse" id="mobile-nav">
-      <ul class="nav navbar-nav visible-xs-block">
-        <li>
-          <a href="{{ url_for('carpool.index') }}">Home</a>
-        </li>
-        <li>
-          <a href="{{ url_for('carpool.mine') }}">My rides</a>
-        </li>
-        <li>
-          <a href="{{ url_for('carpool.find') }}">Find a ride</a>
-        </li>
-        <li>
-          <a href="{{ url_for('carpool.new') }}">Give a ride</a>
-        </li>
+      <ul class="nav navbar-nav hidden-lg">
+        <li><a href="{{ url_for('carpool.index') }}">Home</a></li>
+        <li><a href="{{ url_for('carpool.mine') }}">My rides</a></li>
+        <li><a href="{{ url_for('carpool.find') }}">Find a ride</a></li>
+        <li><a href="{{ url_for('carpool.new') }}">Give a ride</a></li>
         <li role="separator" class="divider"></li>
 {% if current_user.is_authenticated %}
-        <li>
-          <a href="{{ url_for('auth.profile') }}">Profile</a>
-        </li>
-        <li>
-          <a href="#" onClick="return doLogout()">Logout</a>
-        </li>
+        <li><a href="{{ url_for('auth.profile') }}">Profile</a></li>
+        <li><a href="#" onClick="return doLogout()">Logout</a></li>
 {% else %}
-        <li>
-          <a href="{{ url_for('auth.login') }}">Login</a>
-        </li>
+        <li><a href="{{ url_for('auth.login') }}">Login</a></li>
 {% endif %}
       </ul>
-      <ul class="nav navbar-nav hidden-xs wide-nav">
-        <form class="navbar-form" id="ride-select-form" method="GET" action="{{ url_for('carpool.find') }}">
-          <div class="form-group">
-            <select id="ride-select" class="form-control input-lg" >
-              <option value="find-ride">Find a ride&nbsp;&nbsp;&nbsp;</option>
-              <option value="give-ride">Give a ride</option>
-            </select>
-            <span>near</span>
-            <input type="text" name="q" id="locationQuery" class="form-control input-lg"  placeholder="Zip code or City, State"/>
-          </div>
-        </form>
+      <ul class="nav navbar-nav visible-lg-block wide-nav">
+        <li>
+          <form class="navbar-form" id="ride-select-form" method="GET" action="{{ url_for('carpool.find') }}">
+            <div class="form-group">
+              <select id="ride-select" class="form-control input-lg" >
+                <option value="find-ride">Find a ride&nbsp;&nbsp;&nbsp;</option>
+                <option value="give-ride">Give a ride</option>
+              </select>
+              <span>near</span>
+              <input type="text" name="q" id="locationQuery" class="form-control input-lg"  placeholder="Zip code or City, State"/>
+            </div>
+          </form>
+        </li>
+        <li><a href="{{ config.get('BRANDING_PRIVACY_URL') }}">Privacy &amp; Terms</a></li>
+{% if current_user.is_authenticated %}
+        <li><a href="{{ url_for('carpool.mine') }}">My rides</a></li>
+        <li class="dropdown">
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+            {{ current_user.name }}<span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu">
+            <li><a href="{{ url_for('auth.profile') }}">Profile</a></li>
+            <li><a href="#" onClick="return doLogout()">Logout</a></li>
+          </ul>
+        </li>
+{% else %}
+        <li><a href="{{ url_for('auth.login') }}">Login</a>
+{% endif %}
+      </li>
       </ul>
     </div><!-- /.navbar-collapse -->
   </div><!-- /.container-fluid -->

--- a/app/templates/_template.html
+++ b/app/templates/_template.html
@@ -112,63 +112,61 @@ function doLogout() {
 
 {% block content %}
 
-<nav class="global-header">
-  <div class="header-left">
-    <div class="mobile-back-link">
-      <a href="#"><div class="back-button"></div></a>
+<nav class="navbar navbar-default">
+  <div class="container-fluid">
+    <div class="navbar-header ">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#mobile-nav" aria-expanded="false">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <a href="{{ url_for('carpool.index') }}" class="navbar-brand logo generic">
+      </a>
     </div>
-    <div class="logo-container">
-      <a href="{{ url_for('carpool.index') }}"><div class="logo generic"></div></a>
-      <ul class="mobile-nav-bar">
-        <li><a href="{{ url_for('carpool.index') }}">Home</a></li>
+
+    <div class="collapse navbar-collapse" id="mobile-nav">
+      <ul class="nav navbar-nav visible-xs-block">
+        <li>
+          <a href="{{ url_for('carpool.index') }}">Home</a>
+        </li>
+        <li>
+          <a href="{{ url_for('carpool.mine') }}">My rides</a>
+        </li>
+        <li>
+          <a href="{{ url_for('carpool.find') }}">Find a ride</a>
+        </li>
+        <li>
+          <a href="{{ url_for('carpool.new') }}">Give a ride</a>
+        </li>
+        <li role="separator" class="divider"></li>
 {% if current_user.is_authenticated %}
-        <li><a href="{{ url_for('carpool.mine') }}">My rides</a></li>
-{% endif %}
-        <li><a href="{{ url_for('carpool.find') }}">Find a ride</a></li>
-        <li><a href="{{ url_for('carpool.new') }}">Give a ride</a></li>
-        <li class="divider"><a href="{{ config.get('BRANDING_PRIVACY_URL') }}">Privacy &amp; Terms</a></li>
-{% if current_user.is_authenticated %}
-        <li><a href="{{ url_for('auth.profile') }}">Profile</a></li>
-        <li><a href="#" onClick="return doLogout()">Logout</a></li>
+        <li>
+          <a href="{{ url_for('auth.profile') }}">Profile</a>
+        </li>
+        <li>
+          <a href="#" onClick="return doLogout()">Logout</a>
+        </li>
 {% else %}
-        <li><a href="{{ url_for('auth.login') }}">Login</a></li>
+        <li>
+          <a href="{{ url_for('auth.login') }}">Login</a>
+        </li>
 {% endif %}
-        </ul>
-    </div>
-<!-- if this page is related to a find / give page -->
-    <form id="ride-select-form" method="GET" action="{{ url_for('carpool.find') }}" class="header-search-bar">
-      <input type="hidden" id="ride-select-lat" name="lat"></input>
-      <input type="hidden" id="ride-select-lon" name="lon"></input>
-      <select id="ride-select">
-        <option value="find-ride">Find a ride&nbsp;&nbsp;&nbsp;</option>
-        <option value="give-ride">Give a ride</option>
-      </select>
-      <span>near</span>
-      <input type="text" name="q" id="locationQuery" placeholder="Zip code or City, State"/>
-    </form>
-<!-- end if -->
-  </div>
-  <ul class="nav-bar">
-    <li class="active"><a href="{{ url_for('carpool.find') }}">Find a ride</a></li>
-      <li><a href="{{ url_for('carpool.new') }}">Give a ride</a></li>
-      <li><a href="{{ config.get('BRANDING_PRIVACY_URL') }}">Privacy &amp; Terms</a></li>
-{% if current_user.is_authenticated %}
-      <li><a href="{{ url_for('carpool.mine') }}">My rides</a></li>
-{% endif %}
-      <li class="nav-dropdown">
-{% if current_user.is_authenticated %}
-        <a class="arrow" href="#">{{ current_user.name }}</a>
-{% else %}
-        <a href="{{ url_for('auth.login') }}">Login</a>
-{% endif %}
-{% if current_user.is_authenticated %}
-        <ul class="nav-bar-secondary">
-          <li><a href="{{ url_for('auth.profile') }}">Profile</a></li>
-          <li><a href="#" onClick="return doLogout()">Logout</a></li>
-        </ul>
-{% endif %}
-      </li>
-  </ul>
+      </ul>
+      <ul class="nav navbar-nav hidden-xs wide-nav">
+        <form class="navbar-form" id="ride-select-form" method="GET" action="{{ url_for('carpool.find') }}">
+          <div class="form-group">
+            <select id="ride-select" class="form-control input-lg" >
+              <option value="find-ride">Find a ride&nbsp;&nbsp;&nbsp;</option>
+              <option value="give-ride">Give a ride</option>
+            </select>
+            <span>near</span>
+            <input type="text" name="q" id="locationQuery" class="form-control input-lg"  placeholder="Zip code or City, State"/>
+          </div>
+        </form>
+      </ul>
+    </div><!-- /.navbar-collapse -->
+  </div><!-- /.container-fluid -->
 </nav>
 
 {% block site %}{% endblock %}


### PR DESCRIPTION
logo is brand image

with [Bootstrap breakpoints](https://getbootstrap.com/docs/3.3/css/#responsive-utilities)

xs (mobile): collapsible list of links
<img width="366" alt="screen shot 2018-08-05 at 9 41 21 am" src="https://user-images.githubusercontent.com/1649528/43687939-ee828cb4-9893-11e8-970e-e8a81eab7472.png">

sm - md: list of links
<img width="1010" alt="screen shot 2018-08-05 at 9 41 07 am" src="https://user-images.githubusercontent.com/1649528/43687940-ee9ab4e2-9893-11e8-962e-cc75f818284f.png">
 
lg: find/give dropdown plus search input, list of links
<img width="1195" alt="screen shot 2018-08-05 at 9 40 55 am" src="https://user-images.githubusercontent.com/1649528/43687941-eeb21452-9893-11e8-88a5-868b3d65c7a9.png">

fixes #297 

@jillh510: Only [privacy.html](https://github.com/RagtagOpen/nomad/blob/297-mobile-header/app/static/privacy.html) uses a big chunk (~110 lines) of CSS but /privacy.html returns 404, and [terms.html](https://github.com/RagtagOpen/nomad/blob/297-mobile-header/app/templates/auth/terms.html) includes a privacy section
Is  [privacy.html](https://github.com/RagtagOpen/nomad/blob/297-mobile-header/app/static/privacy.html) still used?
If not, we should remove the [`privacy.html header section`](https://github.com/RagtagOpen/nomad/blob/297-mobile-header/app/static/css/styles.css#L188) section of CSS
