### PR TITLE
#566 Fix pagination on admin "Drivers and Riders" page

### DIFF
--- a/app/admin/views.py
+++ b/app/admin/views.py
@@ -160,7 +160,7 @@ def user_list():
 @admin_bp.route('/admin/drivers_and_riders')
 def driver_and_rider_list():
     page = request.args.get('page')
-    page = int(page) if page is not None else 0
+    page = int(page) if page is not None else 1
     per_page = 15
 
     query = '''
@@ -181,16 +181,16 @@ def driver_and_rider_list():
         order by destination, leave_time, person_name
     '''
     result = list(db.engine.execute(query))
-    if per_page * (page + 1) > len(result):
-        result = result[per_page * page:]
+    if per_page * page > len(result):
+        paginated_result = result[per_page * (page - 1):]
     else:
-        result = result[per_page * page:per_page * (page + 1)]
+        paginated_result = result[per_page * (page - 1):per_page * page]
     return render_template(
         'admin/users/drivers_and_riders.html',
-        drivers_and_riders=result,
+        drivers_and_riders=paginated_result,
         page=page,
-        not_last=(per_page * (page + 1) < len(result)),
-        not_first=(page > 0)
+        not_last=(per_page * page) < len(result),
+        not_first=(page > 1)
     )
 
 

--- a/app/templates/admin/users/drivers_and_riders.html
+++ b/app/templates/admin/users/drivers_and_riders.html
@@ -3,56 +3,61 @@
 
 {% block site %}
 <div class="content">
-    <div class="fullscreen">
+  <div class="fullscreen">
     <h4><a href="{{ url_for('admin.admin_index') }}">Admin</a>&nbsp;&raquo;&nbsp;
         Drivers and Riders
     </h4>
     <h1>Nomad Registered Drivers and Riders</h1>
 
-<table class="table table-hover">
-    <thead>
-        <tr>
-            <th>Destination</th>
-            <th>Leave Time</th>
-            <th>Return Time</th>
-            <th>Driver or Rider</th>
-            <th>Name</th>
-            <th>Email</th>
-            <th>Phone</th>
-            <th>Preferred Contact Method</th>
-            <th>User Details Link</th>
-        </tr>
-    </thead>
-    <tbody id='search-results'>
-{% for row in drivers_and_riders %}
-        <tr>
-            <td>{{ row.destination }}</td>
-            <td>{{ row.leave_time }}</td>
-            <td>{{ row.return_time }}</td>
-            <td>{{ row.rider_driver }}</td>
-            <td>{{ row.person_name }}</td>
-            <td>{{ row.email }}</td>
-            <td>{{ row.phone }}</td>
-            <td>{{ row.contact }}</td>
-            <td><a href="{{ url_for('admin.user_show', uuid=row.uuid) }}">Details</a></td>
-        </tr>
-{% endfor %}
-    </tbody>
-</table>
-</table>
-{% if not_first %}
-<a href="{{ url_for('admin.driver_and_rider_list', page=page-1) }}">&lt;&lt; Previous Page</a>
-{% else %}
-&lt;&lt; Previous Page
-{% endif %}
-| {{ page }} |
-{% if not_last %}
-<a href="{{ url_for('admin.driver_and_rider_list', page=page+1) }}">Next Page &gt;&gt;</a>
-{% else %}
-Next Page &gt;&gt;
-{% endif %}
-</br>
-</br>
-<a class="btn btn-primary" href="{{ url_for('admin.user_list_csv') }}">Download as CSV</a>
+    <table class="table table-hover">
+        <thead>
+            <tr>
+                <th>Destination</th>
+                <th>Leave Time</th>
+                <th>Return Time</th>
+                <th>Driver or Rider</th>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Phone</th>
+                <th>Preferred Contact Method</th>
+                <th>User Details Link</th>
+            </tr>
+        </thead>
+        <tbody id='search-results'>
+    {% for row in drivers_and_riders %}
+            <tr>
+                <td>{{ row.destination }}</td>
+                <td>{{ row.leave_time }}</td>
+                <td>{{ row.return_time }}</td>
+                <td>{{ row.rider_driver }}</td>
+                <td>{{ row.person_name }}</td>
+                <td>{{ row.email }}</td>
+                <td>{{ row.phone }}</td>
+                <td>{{ row.contact }}</td>
+                <td><a href="{{ url_for('admin.user_show', uuid=row.uuid) }}">Details</a></td>
+            </tr>
+    {% endfor %}
+        </tbody>
+    </table>
 
+    <p>
+      {% if not_first %}
+        <a href="{{ url_for('admin.driver_and_rider_list', page=page - 1) }}">&lt;&lt; Previous Page</a>
+      {% else %}
+        &lt;&lt; Previous Page
+      {% endif %}
+      | {{ page }} |
+      {% if not_last %}
+        <a href="{{ url_for('admin.driver_and_rider_list', page=page + 1) }}">Next Page &gt;&gt;</a>
+      {% else %}
+        Next Page &gt;&gt;
+      {% endif %}
+    </p>
+
+    <p>
+      <br>
+      <a class="btn btn-primary" href="{{ url_for('admin.user_list_csv') }}">Download as CSV</a>
+    </p>
+  </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
Fixes #566.

Fixed:
* The page number in the pagination block was off by one
* The "Next Page" link never worked due to reuse of a variable.
* Cleaned up some unclosed and invalid HTML tags

QA steps:
* Make sure you have at least 16 drivers and riders in your DB. (It shows 15 per page)
* Go to /admin/drivers-and-riders and test the page number, next, and previous buttons