### PR TITLE
Change email text on main page

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -38,7 +38,7 @@
             </ul>
 
             <h3 class="top-border">Need to contact us?</h3>
-            <p>Email the Nomad team for help: <a href="mailto:{{ config.get('MAIL_DEFAULT_SENDER') }}">{{ config.get('MAIL_DEFAULT_SENDER') }}</a>.</p>
+            <p>Email the {{ config.get('BRANDING_ORG_NAME') }} team for help: <a href="mailto:{{ config.get('BRANDING_SUPPORT_EMAIL') }}">{{ config.get('BRANDING_SUPPORT_EMAIL') }}</a>.</p>
             <p>Got questions about our Privacy Policy or Terms of Use? You can find them <a href="{{ config.get('BRANDING_PRIVACY_URL') }}">here</a>.</p>
 
             <h3 class="top-border">About Nomad</h3>


### PR DESCRIPTION
This PR handles the email part of #575, by using branding org variables instead of the defaults.

cc @jillh510.