### PR TITLE
Only show carpool details if it has not left

### DIFF
--- a/app/carpool/views.py
+++ b/app/carpool/views.py
@@ -239,6 +239,7 @@ def new():
 @pool_bp.route('/carpools/<uuid>', methods=['GET', 'POST'])
 def details(uuid):
     carpool = Carpool.uuid_or_404(uuid)
+    carpool.has_left = carpool.leave_time < datetime.datetime.now(datetime.timezone.utc)
 
     return render_template('carpools/show.html', pool=carpool)
 

--- a/app/carpool/views.py
+++ b/app/carpool/views.py
@@ -239,7 +239,6 @@ def new():
 @pool_bp.route('/carpools/<uuid>', methods=['GET', 'POST'])
 def details(uuid):
     carpool = Carpool.uuid_or_404(uuid)
-    carpool.has_left = carpool.leave_time < datetime.datetime.now(datetime.timezone.utc)
 
     return render_template('carpools/show.html', pool=carpool)
 

--- a/app/templates/carpools/show.html
+++ b/app/templates/carpools/show.html
@@ -17,7 +17,7 @@
 
         <div class="form-page">
 
-	    {% if pool.has_left %}
+	    {% if not pool.future %}
                 <h3>This carpool has left!</h3>
             {%- endif %}
 
@@ -31,7 +31,7 @@
             {%- endif %}
 
 
-        {% if not pool.has_left or current_user_ride_request.status == 'approved' or current_user.is_driver(pool) %}
+        {% if pool.future or current_user_ride_request.status == 'approved' or current_user.is_driver(pool) %}
             <h4>Carpool Status</h4>
 
         {% if current_user_ride_request and current_user_ride_request.status == 'approved'  %}
@@ -155,7 +155,7 @@
             </div>
 
         {%- endif %}
-	{%- endif %} <!-- end has_left if -->
+	{%- endif %} <!-- end not in the future if -->
 
             <div class="two-col-layout first-child top-border">
                 <div class="two-col-column">

--- a/app/templates/carpools/show.html
+++ b/app/templates/carpools/show.html
@@ -17,6 +17,10 @@
 
         <div class="form-page">
 
+	    {% if pool.has_left %}
+                <h3>This carpool has left!</h3>
+            {%- endif %}
+
             {% set current_user_ride_request = current_user.get_ride_request_in_carpool(pool) %}
 
             <h4>Carpool Details</h4>
@@ -27,6 +31,7 @@
             {%- endif %}
 
 
+        {% if not pool.has_left or current_user_ride_request.status == 'approved' or current_user.is_driver(pool) %}
             <h4>Carpool Status</h4>
 
         {% if current_user_ride_request and current_user_ride_request.status == 'approved'  %}
@@ -150,6 +155,7 @@
             </div>
 
         {%- endif %}
+	{%- endif %} <!-- end has_left if -->
 
             <div class="two-col-layout first-child top-border">
                 <div class="two-col-column">


### PR DESCRIPTION
As per https://github.com/RagtagOpen/nomad/issues/412, this hides some important carpool info, as well as the "Request To Join" button if the carpool has left.

It could hide more - what do folks think?

