### PR TITLE
Add a link to the admin pages to the nav

### DIFF
--- a/app/templates/_template.html
+++ b/app/templates/_template.html
@@ -126,21 +126,25 @@ function doLogout() {
     </div>
 
     <div class="collapse navbar-collapse" id="mobile-nav">
-      <ul class="nav navbar-nav hidden-lg">
+      <ul class="nav navbar-nav visible-xs">
         <li><a href="{{ url_for('carpool.index') }}">Home</a></li>
-        <li><a href="{{ url_for('carpool.mine') }}">My rides</a></li>
         <li><a href="{{ url_for('carpool.find') }}">Find a ride</a></li>
         <li><a href="{{ url_for('carpool.new') }}">Give a ride</a></li>
+        <li><a href="{{ config.get('BRANDING_PRIVACY_URL') }}">Privacy &amp; Terms</a></li>
         <li role="separator" class="divider"></li>
 {% if current_user.is_authenticated %}
+        <li><a href="{{ url_for('carpool.mine') }}">My rides</a></li>
         <li><a href="{{ url_for('auth.profile') }}">Profile</a></li>
+        {% if current_user.has_roles('admin') %}
+          <li><a href="{{ url_for('admin.admin_index') }}">Admin Tools</a></li>
+        {% endif %}
         <li><a href="#" onClick="return doLogout()">Logout</a></li>
 {% else %}
         <li><a href="{{ url_for('auth.login') }}">Login</a></li>
 {% endif %}
       </ul>
-      <ul class="nav navbar-nav visible-lg-block wide-nav">
-        <li>
+      <ul class="nav navbar-nav hidden-xs wide-nav">
+        <li class="visible-lg-block">
           <form class="navbar-form" id="ride-select-form" method="GET" action="{{ url_for('carpool.find') }}">
             <div class="form-group">
               <select id="ride-select" class="form-control input-lg" >
@@ -152,15 +156,21 @@ function doLogout() {
             </div>
           </form>
         </li>
+        <li class="hidden-lg"><a href="{{ url_for('carpool.find') }}">Find a ride</a></li>
+        <li class="hidden-lg"><a href="{{ url_for('carpool.new') }}">Give a ride</a></li>
         <li><a href="{{ config.get('BRANDING_PRIVACY_URL') }}">Privacy &amp; Terms</a></li>
 {% if current_user.is_authenticated %}
-        <li><a href="{{ url_for('carpool.mine') }}">My rides</a></li>
+        <li class="hidden-sm"><a href="{{ url_for('carpool.mine') }}">My rides</a></li>
         <li class="dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
             {{ current_user.name }}<span class="caret"></span>
           </a>
           <ul class="dropdown-menu">
+            <li class="visible-sm"><a href="{{ url_for('carpool.mine') }}">My rides</a></li>
             <li><a href="{{ url_for('auth.profile') }}">Profile</a></li>
+            {% if current_user.has_roles('admin') %}
+              <li><a href="{{ url_for('admin.admin_index') }}">Admin Tools</a></li>
+            {% endif %}
             <li><a href="#" onClick="return doLogout()">Logout</a></li>
           </ul>
         </li>


### PR DESCRIPTION
Fixes #568.

Updated the layout of the nav menu a little:

* Added "Admin Tools" link to all versions of the menu
* Added "Privacy & Terms" item to the mobile menu
* Rearranged some of the menu items to make them fit well on "small" (768-1023) screen widths
* Small and up now use the same menu as Large, with the zip code form being hidden on widths < large

If testing this, pay particular attention to the screen widths around 768-800px wide (e.g., iPad in portrait mode) because the menu was wrapping oddly at that size.