### PR TITLE
579: Change home page form colors and text size

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -145,6 +145,9 @@ select:focus {
 	background: white url("../img/ic_search_24px.svg") 7px center no-repeat;
 	text-indent: 25px;
 }
+.navbar {
+    margin-bottom: 0;
+}
 .navbar>.container .navbar-brand, .navbar>.container-fluid .navbar-brand {
 	margin-left: 20px;
 	margin-right: 20px;
@@ -189,7 +192,6 @@ select:focus {
 }
 .fullscreen {
 	width: 100%;
-	margin-top: 70px;
 	padding: 0 210px 100px 210px;
 }
 .fullscreen.jumbo-second {
@@ -230,9 +232,6 @@ select:focus {
 .fullscreen h1, .fullscreen p {
 	max-width: 650px; /*for line length readability*/
 }
-.jumbo {
-	padding-top: 50px;
-}
 .jumbo h2 {
 	padding-top: 0;
 	margin-bottom: 20px;
@@ -265,6 +264,12 @@ select:focus {
 	font-weight: 400;
     font-size: 24px;
 }
+@media screen and (max-width:767px) {
+    .jumbo input[type=text] {
+        max-width: 100%;
+        margin-right: 0;
+    }
+}
 .jumbo input[type=text]::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
     color: #999999;
     opacity: 1; /* Firefox */
@@ -279,6 +284,7 @@ select:focus {
 	-webkit-box-flex: 1;
 	    -ms-flex: 1 0 100px;
 	        flex: 1 0 100px;
+    background-color: rgba(0,168,225,1);
 	height: 50px;
 	font-weight: 400;
     font-size: 24px;

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -89,7 +89,8 @@ input[type=text], input[type=email], input[type=tel], input[type=date] {
 	-moz-border-radius: 5px;
 	-webkit-border-radius: 5px;
 	margin-right: 10px;
-	font: 400 18px/150%;
+	font-size: 18px;
+    line-height: 150%;
 	color: #333;
 }
 input[type=text]:placeholder, input[type=email]:placeholder, input[type=tel]:placeholder, input[type=date]:placeholder {
@@ -139,9 +140,9 @@ select:focus {
 	height: 50px;
 	background: url("../img/logo_ragtag.png") center / contain no-repeat;
 }
-#locationQuery {
+.locationQuery {
 	min-width: 300px;
-	background: url("../img/ic_search_24px.svg") 7px center no-repeat;
+	background: white url("../img/ic_search_24px.svg") 7px center no-repeat;
 	text-indent: 25px;
 }
 .navbar>.container .navbar-brand, .navbar>.container-fluid .navbar-brand {
@@ -261,14 +262,26 @@ select:focus {
 	max-width: 450px;
 	margin-right: 15px;
 	margin-bottom: 15px;
-	font: 400 24px/150%;
+	font-weight: 400;
+    font-size: 24px;
+}
+.jumbo input[type=text]::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
+    color: #999999;
+    opacity: 1; /* Firefox */
+}
+.jumbo input[type=text]:-ms-input-placeholder { /* Internet Explorer 10-11 */
+    color: #999999;
+}
+.jumbo input[type=text]::-ms-input-placeholder { /* Microsoft Edge */
+    color: #999999;
 }
 .jumbo input[type=submit] {
 	-webkit-box-flex: 1;
 	    -ms-flex: 1 0 100px;
 	        flex: 1 0 100px;
 	height: 50px;
-	font: 400 24px/150%;
+	font-weight: 400;
+    font-size: 24px;
 }
 
 /* ===== MAP SEARCH RESULTS ===== */

--- a/app/templates/_template.html
+++ b/app/templates/_template.html
@@ -152,7 +152,7 @@ function doLogout() {
                 <option value="give-ride">Give a ride</option>
               </select>
               <span>near</span>
-              <input type="text" name="q" id="locationQuery" class="form-control input-lg"  placeholder="Zip code or City, State"/>
+              <input type="text" name="q" class="form-control input-lg locationQuery"  placeholder="Zip code or City, State"/>
             </div>
           </form>
         </li>

--- a/app/templates/_template.html
+++ b/app/templates/_template.html
@@ -152,7 +152,7 @@ function doLogout() {
                 <option value="give-ride">Give a ride</option>
               </select>
               <span>near</span>
-              <input type="text" name="q" class="form-control input-lg locationQuery"  placeholder="Zip code or City, State"/>
+              <input type="text" name="q" id="locationQuery" class="form-control input-lg locationQuery"  placeholder="Zip code or City, State"/>
             </div>
           </form>
         </li>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,7 +11,7 @@
             <h1>{{ config.get('BRANDING_HEADLINE_1') }}</h1>
             <h2>{{ config.get('BRANDING_HEADLINE_2') }}</h2>
             <form method="GET" action="{{ url_for('carpool.find') }}"">
-                <input type="text" name="q" class="locationQuery" placeholder="Zip code or City, State"> <input class="btn btn-success" type="submit" value="Find a ride">
+                <input type="text" name="q" placeholder="Zip code or City, State"> <input class="btn btn-default" type="submit" value="Find a ride">
             </form>
             <p>Can you drive? <a href="{{ url_for('carpool.new') }}">Start your own carpool</a> instead.</p>
         </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,7 +11,7 @@
             <h1>{{ config.get('BRANDING_HEADLINE_1') }}</h1>
             <h2>{{ config.get('BRANDING_HEADLINE_2') }}</h2>
             <form method="GET" action="{{ url_for('carpool.find') }}"">
-                <input type="text" name="q" id="locationQuery" placeholder="Zip code or City, State"> <input class="btn btn-default" type="submit" value="Find a ride">
+                <input type="text" name="q" class="locationQuery" placeholder="Zip code or City, State"> <input class="btn btn-success" type="submit" value="Find a ride">
             </form>
             <p>Can you drive? <a href="{{ url_for('carpool.new') }}">Start your own carpool</a> instead.</p>
         </div>


### PR DESCRIPTION
Fixes #579.

I think the form field was originally white and a CSS change turned it blue. I changed it back to white and fixed a CSS font rule that was causing the font to be too small.

Tested in Firefox and Chrome on Ubuntu. The CSS for the placeholder color should work on IE/Edge as well but it hasn't been tested.

Note: I also changed the button color back to light blue as it was in commit 8d2cc7c (before the template file/navbar refactor) to make it stand out from the text field. I also tweaked some margins and padding to remove some white space that wasn't there in 8d2cc7c.