### PR TITLE
Use form to perform logout instead of JavaScript

### DIFF
--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -1,23 +1,16 @@
-from flask import (
-    current_app,
-    flash,
-    redirect,
-    render_template,
-    request,
-    session,
-    url_for,
-)
+from flask import (current_app, flash, redirect, render_template, request,
+                   session, url_for)
 from flask_login import current_user, login_required, login_user, logout_user
-from six.moves.urllib.parse import urlparse, urljoin
+
+from six.moves.urllib.parse import urljoin, urlparse
+
 from . import auth_bp
-from .forms import ProfileForm, ProfileDeleteForm
-from .oauth import OAuthSignIn
 from .. import db, sentry
+from ..carpool.views import (cancel_carpool,
+                             email_driver_rider_cancelled_request)
 from ..models import Person
-from ..carpool.views import (
-    email_driver_rider_cancelled_request,
-    cancel_carpool,
-)
+from .forms import ProfileDeleteForm, ProfileForm
+from .oauth import OAuthSignIn
 
 
 def is_safe_url(target):
@@ -44,7 +37,7 @@ def login():
 @auth_bp.route('/logout', methods=['POST'])
 def logout():
     logout_user()
-    return url_for('carpool.index')
+    return redirect(url_for('carpool.index'))
 
 
 @auth_bp.route('/authorize/<provider>')
@@ -135,7 +128,6 @@ def profile():
         return redirect(next_url)
     elif request.method == 'POST':
         flash("We couldn't save your profile changes. See below for the errors.", 'error')
-
 
     return render_template('profiles/show.html', form=profile_form)
 

--- a/app/templates/_template.html
+++ b/app/templates/_template.html
@@ -148,7 +148,12 @@ function doLogout() {
         {% if current_user.has_roles('admin') %}
           <li><a href="{{ url_for('admin.admin_index') }}">Admin Tools</a></li>
         {% endif %}
-        <li><a href="#" onClick="return doLogout()">Logout</a></li>
+        <li>
+          <form method="POST" action="{{ url_for('auth.logout') }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button type="submit" class="btn">Log out</button>
+          </form>
+        </li>
 {% else %}
         <li><a href="{{ url_for('auth.login') }}">Login</a></li>
 {% endif %}
@@ -183,7 +188,12 @@ function doLogout() {
             {% if current_user.has_roles('admin') %}
               <li><a href="{{ url_for('admin.admin_index') }}">Admin Tools</a></li>
             {% endif %}
-            <li><a href="#" onClick="return doLogout()">Logout</a></li>
+            <li>
+              <form method="POST" action="{{ url_for('auth.logout') }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit" class="btn">Log out</button>
+              </form>
+            </li>
           </ul>
         </li>
 {% else %}

--- a/app/templates/_template.html
+++ b/app/templates/_template.html
@@ -149,7 +149,7 @@ function doLogout() {
           <li><a href="{{ url_for('admin.admin_index') }}">Admin Tools</a></li>
         {% endif %}
         <li>
-          <form method="POST" action="{{ url_for('auth.logout') }}">
+          <form method="POST" action="{{ url_for('auth.logout') }}" id="logout-form">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button type="submit" class="btn">Log out</button>
           </form>

--- a/app/templates/carpools/add_driver.html
+++ b/app/templates/carpools/add_driver.html
@@ -91,7 +91,7 @@ function localInitMap() {
     {%- endif %}
     {%- endwith %}
 
-    <form method="post" class="form-page">
+    <form method="post" class="form-page" id="new-carpool-form">
         {{ form.hidden_tag() }}
         <h4>Start a new carpool</h4>
         <h1>Provide carpool details</h1>

--- a/app/templates/carpools/add_rider.html
+++ b/app/templates/carpools/add_rider.html
@@ -16,7 +16,7 @@
         {%- endif %}
         {%- endwith %}
 
-        <form method='post' class="form-page">
+        <form method='post' class="form-page" id="join-carpool-form">
             {{ form.hidden_tag() }}
             <h4>Join this carpool</h4>
             <h1>Confirm your details</h1>

--- a/app/templates/carpools/edit.html
+++ b/app/templates/carpools/edit.html
@@ -96,7 +96,7 @@ function localInitMap() {
     {%- endif %}
     {%- endwith %}
 
-    <form method="post" class="form-page">
+    <form method="post" class="form-page" id="update-carpool-form">
         {{ form.hidden_tag() }}
         <h4>Edit your carpool</h4>
         <h1>Update carpool details</h1>

--- a/app/templates/carpools/show.html
+++ b/app/templates/carpools/show.html
@@ -40,7 +40,7 @@
                     <p>You are confirmed for this carpool!</p>
                 </div>
                 <div class="two-col-column">
-                    <form name="cancel_rider" action="{{ url_for('carpool.modify_ride_request', carpool_uuid=pool.uuid, request_uuid=current_user_ride_request.uuid, action='cancel') }}" method="POST">
+                    <form name="cancel_rider" action="{{ url_for('carpool.modify_ride_request', carpool_uuid=pool.uuid, request_uuid=current_user_ride_request.uuid, action='cancel') }}" method="POST" id="cancel-rider-form">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                         <button class="btn btn-warning btn-left-button carpool-control-button" type="submit" name="cancel_button">Cancel your seat in carpool</button>
                     </form>
@@ -56,7 +56,7 @@
                     <p>Your ride request is pending.</p>
                 </div>
                 <div class="two-col-column">
-                    <form name="cancel_rider" action="{{ url_for('carpool.modify_ride_request', carpool_uuid=pool.uuid, request_uuid=current_user_ride_request.uuid, action='cancel') }}" method="POST">
+                    <form name="cancel_rider" action="{{ url_for('carpool.modify_ride_request', carpool_uuid=pool.uuid, request_uuid=current_user_ride_request.uuid, action='cancel') }}" method="POST" id="cancel-rider-form">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                         <button class="btn btn-warning left-button carpool-control-button" type="submit" name="cancel_button">Cancel your seat request</button>
                     </form>
@@ -99,24 +99,24 @@
                     <strong>Waiting for your response&nbsp;</strong>
                     </div>
                         {% if pool.seats_available %}
-                        <form name="approve_rider" action="{{ url_for('carpool.modify_ride_request', action='approve', carpool_uuid=pool.uuid, request_uuid=request.uuid) }}" method="POST">
+                        <form name="approve_rider" action="{{ url_for('carpool.modify_ride_request', action='approve', carpool_uuid=pool.uuid, request_uuid=request.uuid) }}" method="POST" id="approve-rider-form">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                             <button class="btn btn-success left-button carpool-control-button" type="submit" name="approve_button">Approve</button>
                         </form>
                         {% endif %}
-                        <form name="deny_rider" action="{{ url_for('carpool.modify_ride_request', action='deny', carpool_uuid=pool.uuid, request_uuid=request.uuid) }}" method="POST">
+                        <form name="deny_rider" action="{{ url_for('carpool.modify_ride_request', action='deny', carpool_uuid=pool.uuid, request_uuid=request.uuid) }}" method="POST" id="deny-rider-form">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                             <button class="btn btn-danger carpool-control-button" type="submit" name="deny_button">Deny</button>
                         </form>
                     {%- elif request.status == 'approved' %}
                     <strong>You approved their request&nbsp;</strong>
-                        <form name="deny_approved_rider" action="{{ url_for('carpool.modify_ride_request', action='deny', carpool_uuid=pool.uuid, request_uuid=request.uuid) }}" method="POST">
+                        <form name="deny_approved_rider" action="{{ url_for('carpool.modify_ride_request', action='deny', carpool_uuid=pool.uuid, request_uuid=request.uuid) }}" method="POST" id="deny-approved-rider-form">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                             <button class="btn btn-danger carpool-control-button" type="submit" name="deny_button">Deny</button>
                         </form>
                     {%- elif request.status == 'denied' %}
                     <strong>You denied their request&nbsp;</strong>
-                        <form name="approve_denied_rider" action="{{ url_for('carpool.modify_ride_request', action='approve', carpool_uuid=pool.uuid, request_uuid=request.uuid) }}" method="POST">
+                        <form name="approve_denied_rider" action="{{ url_for('carpool.modify_ride_request', action='approve', carpool_uuid=pool.uuid, request_uuid=request.uuid) }}" method="POST" id="approve-denied-rider-form">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                             <button class="btn btn-success carpool-control-button" type="submit" name="approve_button">Approve</button>
                         </form>

--- a/app/templates/profiles/show.html
+++ b/app/templates/profiles/show.html
@@ -35,7 +35,7 @@
         {%- endif %}
         {%- endwith %}
 
-        <form method="post" class="form-page">
+        <form method="post" class="form-page" id="update-profile-form">
             {{ form.hidden_tag() }}
             <h1>Edit your profile</h1>
             <p>Make changes to your personal information or delete your account.</p>

--- a/tests/functional/test_profile.py
+++ b/tests/functional/test_profile.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 import urllib
 from http import HTTPStatus
-from . import login_person
 
-from ..factories import PersonFactory, CarpoolFactory, DestinationFactory, RideRequestFactory
+from . import login_person
+from ..factories import (CarpoolFactory, DestinationFactory, PersonFactory,
+                         RideRequestFactory)
 
 
 class TestProfile:
@@ -18,7 +19,7 @@ class TestProfile:
         login_person(testapp, person)
         res = testapp.get('/profile')
         assert res.status_code == HTTPStatus.OK
-        form = res.forms[1]
+        form = res.forms['update-profile-form']
         form['name'] = 'foo'
         form['gender'] = 'Female'
         form['preferred_contact'] = 'email'


### PR DESCRIPTION
Addresses #254

Replace the JavaScript method of logging out users with a traditional form POSTing to /logout. This takes care of CSRF issues from #254 and clears the session cookie which seems to be the root problem of #228 

Let's have someone make the form button look like the other links in the menu before this gets merged (or make that a new issue).