### PR TITLE
#607: Make "Logout" button in nav look like the other nav menu links

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -159,6 +159,27 @@ select:focus {
 .navbar-nav li a {
 	line-height: 30px;
 }
+/** The logout button in the nav is a <button> made to look like a <a> tag **/
+.btn-logout {
+    background-color: transparent;
+    border: none;
+    font-size: 16px;
+    padding-left: 20px;
+    padding-right: 20px;
+    text-align: left;
+    text-decoration: underline;
+    width: 100%;
+}
+.btn-logout:hover {
+    text-decoration: none;
+}
+@media screen and (max-width:767px) {
+    .btn-logout {
+        color: rgb(119, 119, 119);
+        padding-left: 15px;
+        padding-right: 15px;
+    }
+}
 
 .mobile-back-link {
 	position: fixed;

--- a/app/templates/_template.html
+++ b/app/templates/_template.html
@@ -151,7 +151,7 @@ function doLogout() {
         <li>
           <form method="POST" action="{{ url_for('auth.logout') }}" id="logout-form">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button type="submit" class="btn">Log out</button>
+            <button type="submit" class="btn btn-logout">Log out</button>
           </form>
         </li>
 {% else %}
@@ -191,7 +191,7 @@ function doLogout() {
             <li>
               <form method="POST" action="{{ url_for('auth.logout') }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <button type="submit" class="btn">Log out</button>
+                <button type="submit" class="btn btn-logout">Log out</button>
               </form>
             </li>
           </ul>


### PR DESCRIPTION
Fixes #607.

In issue #254, the logout button was changed from an `<a>` tag to a `<button>` tag. This required some changes to the CSS to make it look consistent with the other links in the admin. CSS change is in this PR.

Tested in Firefox and Chrome on Linux at all breakpoints from xs (<767px) up to lg (>1200px).

Testing instructions:
- Log in
- Expand the hamburger menu (mobile sizes) or the user dropdown in the far right of the nev menu (desktop sizes). Observe styling of the "Logout" button. It should look just like the links above it. Same color, padding, hover effect, etc.