### PR TITLE
move zendesk widget to main template

### DIFF
--- a/app/templates/_template.html
+++ b/app/templates/_template.html
@@ -206,5 +206,7 @@ function doLogout() {
 </nav>
 
 {% block site %}{% endblock %}
+<!--Zendesk support widget-->
+<script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=19972695-e94b-40d7-be27-3f1c22dc0bc5"> </script>
 
 {%- endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -42,9 +42,6 @@
             <p>For questions about carpools, canvasses, schedules, canvas locations, etc. please email the {{ config.get('BRANDING_ORG_NAME') }} team for help: <a href="mailto:{{ config.get('BRANDING_SUPPORT_EMAIL') }}">{{ config.get('BRANDING_SUPPORT_EMAIL') }}</a>.</p>
             <p>For questions about how to use the Nomad tool, email <a href="mailto:support@ragtag.org">support@ragtag.org</a> or click on the “help” button below.</p>
             <p>You can find the Terms of Use and Privacy Policy <a href="{{ config.get('BRANDING_PRIVACY_URL') }}">here</a>.</p>
-	    <!--Zendesk support widget-->
-	    <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=19972695-e94b-40d7-be27-3f1c22dc0bc5"> </script>
-
 
             <h3 class="top-border">About Nomad</h3>
             <p>Nomad was built by Ragtag, a team of tech volunteers who help activists, organizers, non-profits, and candidates break down tech barriers making it easier to achieve their organizing goals. Nomad lets volunteers help their fellow volunteers get to where they can have the biggest impact.</p>


### PR DESCRIPTION
Fixes #629 by moving the widget to the main template, so it is visible on all pages.  cc @jillh510.