### PR TITLE
#618: Update date format on email subject lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
     ```
 
 1.  (Optional) Configure Google Sign-In
+
     In order to test Google authentication you'll need to create a [Console Project](https://developers.google.com/identity/sign-in/web/devconsole-project).  
     For "Where are you calling from?" choose "Web server".  
     For "Authorized redirect URIs" enter http://localhost:5000/callback/google.  
@@ -53,27 +54,9 @@
     echo GOOGLE_CLIENT_SECRET=YOUR_CLIENT_SECRET >> .env
     ```
 
-
 1.  Configure Email Send
-    In order for the app to send email, you'll need to add details about what mail server it should use. For testing, you can use a Mailgun or Gmail account. Add those details to the .env file, too!
 
-```bash
-echo MAIL_SERVER=smtp.mailgun.org >> .env
-echo MAIL_PORT=465 >> .env
-echo MAIL_USE_SSL=1 >> .env
-echo MAIL_USERNAME=your_username >> .env
-echo MAIL_PASSWORD=your_password >> .env
-```
-
-If you want to test emails without actually sending them, you can use [MailDev](http://danfarrelly.nyc/MailDev/) with Docker and the following `.env` configuration:
-
-```bash
-echo MAIL_SERVER=fakesmtp >> .env
-echo MAIL_PORT=25 >> .env
-echo MAIL_USE_SSL=0 >> .env
-```
-
-With that setup, you can run `docker-compose up nomad fakesmtp` and view emails at [http://localhost:8081/](http://localhost:8081/).
+    In order for the app to send email, you'll need to add details about what mail server it should use. See [Sending Email](#sending-email) below for instructions.
 
 ## Running with Docker Compose
 
@@ -229,6 +212,67 @@ Once you have the app running with Docker or locally, you need to add your first
 
 1.  Visit `http://127.0.0.1:5000/admin` to verify your account now has the appropriate role.
 
+## Sending Email
+
+The app has several email templates built in. In order to test them locally, you'll need to set up a few things.
+
+### Reading email in the Flask logs
+
+By default, the email recipient, subject, and body of any outgoing message is written to the app's built-in logger, which is the console where you ran `flask run` from. When the app sends an email (e.g., when requesting a spot in a carpool) look for the email contents in that terminal window.
+
+### Configuring SMTP settings
+
+For more advanced testing, you can configure some SMTP settings to send to an actual mail server.
+
+#### Mailgun or Gmail
+
+For testing, you can use a Mailgun or Gmail account. Edit your .env file and add the following:
+
+```python
+MAIL_LOG_ONLY=false
+MAIL_SERVER=smtp.mailgun.org
+MAIL_PORT=465
+MAIL_USE_SSL=1
+MAIL_USERNAME=your_username
+MAIL_PASSWORD=your_password
+```
+
+#### MailDev
+
+[MailDev](http://danfarrelly.nyc/MailDev/) is a simple Node utility to listen for incoming SMTP connections and display the messages in an ephemeral Inbox.
+
+With Docker, you can use the following `.env` configuration:
+
+```bash
+echo MAIL_SERVER=fakesmtp >> .env
+echo MAIL_PORT=25 >> .env
+echo MAIL_USE_SSL=0 >> .env
+```
+
+With that setup, you can run `docker-compose up nomad fakesmtp` and view emails at [http://localhost:8081/](http://localhost:8081/).
+
+To set up MailDev without Docker, run the following in a separate Terminal from your main one:
+
+```bash
+npm install -g maildev    # this may require sudo on some systems
+maildev
+```
+
+This should listen for email on 127.0.0.1 port 1025 and provide a browser interface at http://localhost:1080 which shows an Inbox of messages sent by the app. Keep that terminal window running in the background.
+
+In your .env file, add the following:
+
+```python
+# Maildev
+MAIL_LOG_ONLY=false
+MAIL_SERVER=localhost
+MAIL_PORT=1025
+MAIL_USE_SSL=false
+MAIL_USE_TLS=false
+```
+
+Then run `source .env` and `flask run` again to activate the changes.
+
 ## Running tests
 
 Using Docker:
@@ -240,6 +284,7 @@ Using Docker:
 Locally:
 
     ```
+    pipenv install -d
     pytest
     ```
 

--- a/app/admin/views.py
+++ b/app/admin/views.py
@@ -405,9 +405,7 @@ def destinations_delete(uuid):
 def _send_destination_action_email(destination, verb, template_base):
     for carpool in destination.carpools:
         subject = 'Carpool on {} {}'.format(
-            carpool.leave_time.strftime(
-                current_app.config.get('DATE_FORMAT')
-            ),
+            carpool.leave_time_formatted,
             verb
         )
 
@@ -447,6 +445,7 @@ def destinations_toggle_hidden(uuid):
         flash("Your destination was unhidden", 'success')
 
     return redirect(url_for('admin.destinations_show', uuid=uuid))
+
 
 @admin_bp.route('/admin/emailpreview/<template>')
 def email_preview(template):

--- a/app/carpool/views.py
+++ b/app/carpool/views.py
@@ -145,7 +145,7 @@ def start_geojson():
                 'seats_available': pool.seats_available,
                 'leave_time': pool.leave_time.isoformat(),
                 'return_time': pool.return_time.isoformat(),
-                'leave_time_human': pool.leave_time.strftime(dt_format),
+                'leave_time_human': pool.leave_time_formatted,
                 'return_time_human': pool.return_time.strftime(dt_format),
                 'driver_gender': escape(pool.driver.gender),
                 'is_approximate_location': is_approximate_location,
@@ -497,7 +497,7 @@ def _email_carpool_cancelled(carpool, reason, notify_driver):
         reason = '<reason not given>'
 
     subject = 'Carpool session on {} cancelled'.format(
-        carpool.leave_time.strftime(current_app.config.get('DATE_FORMAT')))
+        carpool.leave_time_formatted)
 
     for rider in riders:
         send_email(
@@ -535,7 +535,7 @@ def _email_driver(carpool, current_user, subject, template_name_specifier, ride_
 
 def _email_driver_ride_requested(carpool, ride_request, current_user):
     subject = '{} requested a ride in carpool on {}'.format(
-        current_user.name, carpool.leave_time)
+        current_user.name, carpool.leave_time_formatted)
 
     _email_driver(carpool, current_user, subject, 'ride_requested', ride_request)
 
@@ -543,9 +543,7 @@ def _email_driver_ride_requested(carpool, ride_request, current_user):
 def _email_ride_status(request, subject_beginning, template_name_specifier):
     subject = '{} for carpool on {}'.format(
         subject_beginning,
-        request.carpool.leave_time.strftime(
-            current_app.config.get('DATE_FORMAT')
-        )
+        request.carpool.leave_time_formatted
     )
 
     send_email(
@@ -574,8 +572,7 @@ def email_driver_rider_cancelled_request(request, carpool, current_user):
 
 def _email_driver_rider_cancelled_request(carpool, current_user):
     subject = '{} cancelled their request to ride in carpool on {}'.format(
-        current_user.name, carpool.leave_time.strftime(
-            current_app.config.get('DATE_FORMAT')))
+        current_user.name, carpool.leave_time_formatted)
 
     _email_driver(carpool, current_user, subject, 'ride_request_cancelled')
 
@@ -583,9 +580,7 @@ def _email_driver_rider_cancelled_request(carpool, current_user):
 def _email_driver_rider_cancelled_approved_request(carpool, current_user):
     subject = '{} withdrew from the carpool on {}'.format(
         current_user.name,
-        carpool.leave_time.strftime(
-            current_app.config.get('DATE_FORMAT')
-        )
+        carpool.leave_time_formatted
     )
 
     _email_driver(carpool, current_user, subject,

--- a/app/config.py
+++ b/app/config.py
@@ -67,6 +67,7 @@ class Config:
     SENTRY_DSN = os.environ.get('SENTRY_DSN')
 
     DATE_FORMAT = os.environ.get('DATE_FORMAT', '%a %b %-d %Y at %-I:%M %p')
+    DATE_FORMAT_SHORT = os.environ.get('DATE_FORMAT', '%B %-d, %Y')
 
     BRANDING_ORG_NAME = os.environ.get('BRANDING_ORG_NAME') or \
         'Ragtag'

--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,7 @@
 import datetime
 import uuid
 from dateutil import tz
-from flask import abort
+from flask import abort, current_app
 from flask_login import AnonymousUserMixin, UserMixin
 from geoalchemy2 import Geometry
 from geoalchemy2.shape import to_shape
@@ -145,6 +145,9 @@ class Person(UserMixin, db.Model, UuidMixin):
 
         return requested_role_set.issubset(our_role_set)
 
+    def __str__(self):
+        return self.name + " (" + self.email + ")"
+
 
 @login_manager.user_loader
 def load_user(id):
@@ -209,6 +212,14 @@ class Carpool(db.Model, UuidMixin):
     def future(self):
         now = datetime.datetime.now().replace(tzinfo=tz.gettz('UTC'))
         return self.leave_time > now
+
+    @property
+    def leave_time_formatted(self):
+        """
+        The carpool leave time, formatted as a string, using the default "short" date
+        format, e.g., "January 1, 2018"
+        """
+        return self.leave_time.strftime(current_app.config.get('DATE_FORMAT_SHORT'))
 
 
 class Destination(db.Model, UuidMixin):

--- a/app/templates/email/carpool_cancelled.html
+++ b/app/templates/email/carpool_cancelled.html
@@ -1,7 +1,7 @@
 {% extends "email/_wrapper.html" %}
 
 {% block content %}
-<p>Hello {{ person.name }},</p>
+<p>Hello {{ rider.name }},</p>
 
 <p>Unfortunately, the carpool from {{ carpool.from_place }} to {{ carpool.destination.name }} at {{ carpool.leave_time | humanize }} has been cancelled.</p>
 


### PR DESCRIPTION
Fixes #618.

* Update the display of the carpool date in email subjects to "January 1, 2018" format (human readable, without the time)
* Added a convenience property "leave_time_formatted" to the Carpool model class
* Fixed an "undefined variable" error in the "Carpool Canceled" email template
* Update README with more detailed instructions for sending email and MailDev
