### PR TITLE
Fix links in Carpool pages (#638, #639)

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -193,6 +193,19 @@ class Carpool(db.Model, UuidMixin):
             Person.id.in_(p.person_id for p in requests)).all()
 
     @property
+    def from_lat_lng(self):
+        """
+        Returns the from point in a lat-lng string useful for Google Maps,
+        e.g., "38.518, -97.328"
+        """
+
+        # Shapely's Point class can extract lat and long from the geometry data type
+        pt = to_shape(self.from_point)
+        lat = pt.y
+        lng = pt.x
+        return "{}, {}".format(lat, lng)
+
+    @property
     def riders(self):
         return self.get_riders(['approved'])
 

--- a/app/templates/carpools/mine.html
+++ b/app/templates/carpools/mine.html
@@ -19,7 +19,7 @@
                 <div class="carpool">
                     <h2>{{ pool.leave_time | humanize }}</h2>
                     <h3>
-                        <a href="https://maps.google.com/?q={{ pool.from_place }}" target="_blank">{{ pool.from_place }}</a> to {{ pool.destination.name }}
+                        <a href="{{ url_for('carpool.details', uuid=pool.uuid) }}">{{ pool.from_place }} to {{ pool.destination.name }}</a>
                     </h3>
 
                 {% set current_user_ride_request = current_user.get_ride_request_in_carpool(pool) %}
@@ -55,13 +55,13 @@
                         </div>
                         <div class="two-col-column">
                             <h4>Departure Point</h4>
-                            <p>{{ pool.from_place }}</p>
+                            <p><a href="https://maps.google.com/?q={{ pool.from_lat_lng | urlencode }}" target="_blank">{{ pool.from_place }}</a></p>
                             <h4>Destination</h4>
                             <p>
                                 {{ pool.destination.name }}
                             {% if current_user.is_driver(pool) or current_user_ride_request and current_user_ride_request.status == 'approved' %}
                                 <br>
-                                <a href="https://maps.google.com/?q={{ pool.destination.address }}" target="_blank">{{ pool.destination.address }}</a>
+                                <a href="https://maps.google.com/?q={{ pool.destination.address | urlencode }}" target="_blank">{{ pool.destination.address }}</a>
                             {% endif %}
                             </p>
                         </div>

--- a/app/templates/carpools/show.html
+++ b/app/templates/carpools/show.html
@@ -17,9 +17,12 @@
 
         <div class="form-page">
 
-	    {% if not pool.future %}
-            <h3>This carpool has left!</h3>
-        {%- endif %}
+            <h2>Carpool: {{ pool.from_place }} to {{ pool.destination.name }}</h2>
+            <h4>{{ pool.leave_time | humanize }}</h4>
+
+	          {% if not pool.future %}
+                <h3>This carpool has left!</h3>
+            {%- endif %}
 
         {% set current_user_ride_request = current_user.get_ride_request_in_carpool(pool) %}
 
@@ -158,25 +161,17 @@
                 <div class="two-col-column">
                     <h4>Departs</h4>
                     <p>{{ pool.leave_time | humanize }}</p>
-                    <h4>Destination</h4>
-                    <p><a href="https://maps.google.com/?q={{ pool.destination.address }}" target="_blank">{{ pool.destination.name }}</a></p>
-                </div>
-                <div class="two-col-column">
-                    <h4>Departure Point</h4>
-                    <p><a href="https://maps.google.com/?q={{ pool.from_place }}" target="_blank">{{ pool.from_place }}</a></p>
-                    {% if current_user.is_driver(pool) or (current_user_ride_request and current_user_ride_request.status == 'approved') %}
-                    <h4>Destination address</h4>
-                    <p><a href="https://maps.google.com/?q={{ pool.destination.address }}" target="_blank">{{ pool.destination.address }}</a></p>
-                    {% endif %}
-                </div>
-            </div>
-
-            <div class="two-col-layout">
-                <div class="two-col-column">
                     <h4>Returns</h4>
                     <p>{{ pool.return_time | humanize }}</p>
                 </div>
                 <div class="two-col-column">
+                    <h4>Departure Point</h4>
+                    <p><a href="https://maps.google.com/?q={{ pool.from_lat_lng | urlencode }}" target="_blank">{{ pool.from_place }}</a></p>
+                    <h4>Destination</h4>
+                    <p>{{ pool.destination.name }}</p>
+                    {% if current_user.is_driver(pool) or (current_user_ride_request and current_user_ride_request.status == 'approved') %}
+                        <p><a href="https://maps.google.com/?q={{ pool.destination.address | urlencode }}" target="_blank">{{ pool.destination.address }}</a></p>
+                    {% endif %}
                 </div>
             </div>
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,8 +3,10 @@
 import datetime as dt
 
 import pytest
+from geoalchemy2.shape import from_shape
+from shapely.geometry import Point
 
-from app.models import Person, Role, AnonymousUser, Destination
+from app.models import Person, Role, AnonymousUser, Destination, Carpool
 
 from .factories import CarpoolFactory, PersonFactory, RideRequestFactory, DestinationFactory
 
@@ -245,6 +247,14 @@ class TestCarpool:
         db.session.commit()
 
         assert carpool.seats_available == 3
+
+    def test_lat_lng_calculation(self):
+        # the hex string below represents a PostGIS Geometry object)
+        pt = wkb_element = from_shape(Point(-97.328, 38.518), srid=4326)
+        c = Carpool()
+        c.from_point=pt
+        assert c.from_lat_lng == '38.518, -97.328'
+
 
 @pytest.mark.usefixtures('db')
 class TestDestination:


### PR DESCRIPTION
Fixes #638.
Fixes #639.

* Make the carpool title be a link to the carpool details, so all users can reach the details page (previously just the driver had this link)
* Fix a bug where Google Maps links would break if you renamed the "from" point to something generic like "Safeway parking lot"

To test:
* Log in as one user, and create a carpool. After choosing the "from" location, rename the location by typing into the text field to the right of the map. Type something generic (even "foo" would work)
* Log in as another user. Search for the carpool and request a spot
* Go to My Rides
* The carpool title should be a link to the detail page (see #638)
* The "From" location should be a link to Google Maps, with the Lat and Long in the query string. The link should take you to the right spot on the map, even if the name is super generic. (See #639)

