### PR TITLE
Add link to carpool to carpool page

### DIFF
--- a/app/templates/carpools/show.html
+++ b/app/templates/carpools/show.html
@@ -191,6 +191,10 @@
                     <h4>Additional notes</h4>
                     <p>{{ pool.notes or "(None supplied)"}}</p>
                 </div>
+                <div class="two-col-column">
+                    <h4>Link to this carpool</h4>
+                    <p><a href="{{ request.url }}">{{ request.url }}</a></p>
+                </div>
             </div>
 
         </div>


### PR DESCRIPTION
cc @jillh510, this closes #647 - it just adds the request URL to the last column.