### PR TITLE
#597: Separate "Give a Ride" and "Find a Ride" on the top nav

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -67,7 +67,7 @@ class Config:
     SENTRY_DSN = os.environ.get('SENTRY_DSN')
 
     DATE_FORMAT = os.environ.get('DATE_FORMAT', '%a %b %-d %Y at %-I:%M %p')
-    DATE_FORMAT_SHORT = os.environ.get('DATE_FORMAT', '%B %-d, %Y')
+    DATE_FORMAT_SHORT = os.environ.get('DATE_FORMAT_SHORT', '%B %-d, %Y')
 
     BRANDING_ORG_NAME = os.environ.get('BRANDING_ORG_NAME') or \
         'Ragtag'

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -140,10 +140,8 @@ select:focus {
 	height: 50px;
 	background: url("../img/logo_ragtag.png") center / contain no-repeat;
 }
-.locationQuery {
-	min-width: 300px;
-	background: white url("../img/ic_search_24px.svg") 7px center no-repeat;
-	text-indent: 25px;
+#locationQuery {
+	min-width: 200px;
 }
 .navbar {
     margin-bottom: 0;
@@ -159,6 +157,17 @@ select:focus {
 .navbar-nav li a {
 	line-height: 30px;
 }
+.navbar-form #locationQuery {
+	font-size: 16px;
+	height: 39px;
+	margin-right: 0;
+}
+.navbar-form button {
+	border-radius: 5px;
+	font-size: 18px;
+	padding: 5px 10px;
+}
+
 /** The logout button in the nav is a <button> made to look like a <a> tag **/
 .btn-logout {
     background-color: transparent;

--- a/app/static/img/ic_search_24px.svg
+++ b/app/static/img/ic_search_24px.svg
@@ -1,4 +1,4 @@
-<svg fill="rgba(2,46,91,.2)" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<svg fill="rgba(0,0,0,.5)" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
     <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
     <path d="M0 0h24v24H0z" fill="none"/>
 </svg>

--- a/app/templates/_template.html
+++ b/app/templates/_template.html
@@ -172,26 +172,23 @@ function doLogout() {
             <input type="hidden" name="lat">
             <input type="hidden" name="lng">
             <div class="form-group">
-              <select id="ride-select" class="form-control input-lg" >
-                <option value="find-ride">Find a ride&nbsp;&nbsp;&nbsp;</option>
-                <option value="give-ride">Give a ride</option>
-              </select>
-              <span>near</span>
-              <input type="text" name="q" id="locationQuery" class="form-control input-lg location-input"  placeholder="Zip code or City, State" value="{{user_query}}"/>
+              <span>Find a ride near</span>
+              <input type="text" name="q" id="locationQuery" class="form-control input-lg location-input"  placeholder="Zip code or City, State" value="{{user_query}}" />
+              <button class="btn btn-secondary"><img src="/static/img/ic_search_24px.svg"></button>
             </div>
           </form>
         </li>
         <li class="hidden-lg"><a href="{{ url_for('carpool.find') }}">Find a ride</a></li>
-        <li class="hidden-lg"><a href="{{ url_for('carpool.new') }}">Give a ride</a></li>
-        <li><a href="{{ config.get('BRANDING_PRIVACY_URL') }}">Privacy &amp; Terms</a></li>
+        <li><a href="{{ url_for('carpool.new') }}">Give a ride</a></li>
 {% if current_user.is_authenticated %}
-        <li class="hidden-sm"><a href="{{ url_for('carpool.mine') }}">My rides</a></li>
+        <li><a href="{{ url_for('carpool.mine') }}">My rides</a></li>
+        <li class="hidden-sm"><a href="{{ config.get('BRANDING_PRIVACY_URL') }}">Privacy &amp; Terms</a></li>
         <li class="dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
             {{ current_user.name }}<span class="caret"></span>
           </a>
           <ul class="dropdown-menu">
-            <li class="visible-sm"><a href="{{ url_for('carpool.mine') }}">My rides</a></li>
+            <li class="visible-sm"><a href="{{ config.get('BRANDING_PRIVACY_URL') }}">Privacy &amp; Terms</a></li>
             <li><a href="{{ url_for('auth.profile') }}">Profile</a></li>
             {% if current_user.has_roles('admin') %}
               <li><a href="{{ url_for('admin.admin_index') }}">Admin Tools</a></li>
@@ -205,6 +202,7 @@ function doLogout() {
           </ul>
         </li>
 {% else %}
+        <li><a href="{{ config.get('BRANDING_PRIVACY_URL') }}">Privacy &amp; Terms</a></li>
         <li><a href="{{ url_for('auth.login') }}">Login</a>
 {% endif %}
       </li>


### PR DESCRIPTION
Fixes #597.

* Removed the "Find a Ride" / "Give a Ride" dropdown, Replaced with "Find a ride near..." text and a separate "Give a Ride" link.
* Also placed "My Rides" link next to "Give a Ride" because it seems more logical there
* Reused the magnifying glass image that was formerly inside the text field; placed it in the new button and darkened the color a bit

![image](https://user-images.githubusercontent.com/727401/45067786-7b3e1e00-b079-11e8-96d6-9e30903d91b8.png)
