### PR TITLE
Messaging for canceled carpools

### DIFF
--- a/app/admin/views.py
+++ b/app/admin/views.py
@@ -263,6 +263,7 @@ def carpool_list_csv():
                      'leave time', 'return time',
                      'driver name', 'drive email',
                      'max riders', 'ride requests', 'approved riders',
+                     'status', 'reason for cancellation'
                      ])
 
     query = '''
@@ -273,6 +274,8 @@ def carpool_list_csv():
                cp.return_time as return_time,
                dp.name as driver_name, dp.email as driver_email,
                cp.max_riders as max_riders,
+               cp.canceled as canceled,
+               cp.cancel_reason as cancel_reason,
                (select count(*) from riders where carpool_id=cp.id) as request_count,
                (select count(*) from riders where carpool_id=cp.id and status='approved') as approved_count
         from carpools cp
@@ -293,6 +296,8 @@ def carpool_list_csv():
             row.max_riders,
             row.request_count,
             row.approved_count,
+            "Canceled" if row.canceled else 'Active',
+            row.cancel_reason,
         ])
 
     return Response(

--- a/app/models.py
+++ b/app/models.py
@@ -174,6 +174,8 @@ class Carpool(db.Model, UuidMixin):
     vehicle_description = db.Column(db.Text)
     driver_id = db.Column(db.Integer, db.ForeignKey('people.id'))
     destination_id = db.Column(db.Integer, db.ForeignKey('destinations.id'))
+    canceled = db.Column(db.Boolean, default=False)
+    cancel_reason = db.Column(db.String, nullable=True)
 
     ride_requests = relationship("RideRequest", cascade="all, delete-orphan")
     destination = relationship("Destination")

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -568,14 +568,20 @@ select:focus {
 	display: inline-block;
 	margin-left: 12px;
 }
-.my-rides .carpools {
-	margin-bottom: 30px;
-}
 .my-rides .carpools .buttons {
 	margin: 15px 0 15px 0;
 }
 .my-rides .carpools.past h3, .my-rides .carpools.past h4 {
 	color: #666;
+}
+.my-rides .carpool {
+	border-bottom: 1px solid #999999;
+	margin-bottom: 20px;
+	padding-bottom: 20px;
+}
+.my-rides .carpool:last-of-type {
+	border-bottom: none;
+	margin-bottom: 20px;
 }
 .my-rides .carpool h2 {
 	font: 700 16px/150%;

--- a/app/templates/_flash_messages.html
+++ b/app/templates/_flash_messages.html
@@ -1,0 +1,9 @@
+{%- with messages = get_flashed_messages(with_categories=True) %}
+{%- if messages %}
+<div class="error-messages">
+    {% for cat, msg in messages %}
+    <div class="message {{ cat }}">{{ msg }}</div>
+    {% endfor %}
+</div>
+{%- endif %}
+{%- endwith %}

--- a/app/templates/admin/carpool/list.html
+++ b/app/templates/admin/carpool/list.html
@@ -21,6 +21,7 @@
             <th>Max Riders</th>
             <th>All requests (pending and approved)</th>
             <th>Approved Riders</th>
+            <th>Status</th>
             <th>Carpool Details Link</th>
         </tr>
     </thead>
@@ -36,6 +37,7 @@
             <td>{{ carpool.max_riders }}</td>
             <td>{{ carpool.riders_and_potential_riders|length }}</td>
             <td>{{ carpool.riders|length }}</td>
+            <td>{% if carpool.canceled %}Canceled{% else %}Active{% endif %}</td>
             <td><a href="{{ url_for('carpool.details', uuid=carpool.uuid) }}">Details</a></td>
         </tr>
 {% endfor %}

--- a/app/templates/admin/destinations/add.html
+++ b/app/templates/admin/destinations/add.html
@@ -59,15 +59,7 @@ function initMap() {
     </h4>
     <h1>New Destination</h1>
 
-{%- with messages = get_flashed_messages(with_categories=True) %}
-{%- if messages %}
-<div class="error-messages">
-    {% for cat, msg in messages %}
-    <div class="message {{ cat }}">{{ msg }}</div>
-    {% endfor %}
-</div>
-{%- endif %}
-{%- endwith %}
+    {% include '_flash_messages.html' %}
 
 <form class='form' method='post'>
 {{ form.hidden_tag() }}

--- a/app/templates/admin/destinations/edit.html
+++ b/app/templates/admin/destinations/edit.html
@@ -60,16 +60,7 @@ function initMap() {
 {% block site %}
 <div class="content">
     <div class="fullscreen">
-
-{%- with messages = get_flashed_messages(with_categories=True) %}
-{%- if messages %}
-<div class="error-messages">
-    {% for cat, msg in messages %}
-    <div class="message {{ cat }}">{{ msg }}</div>
-    {% endfor %}
-</div>
-{%- endif %}
-{%- endwith %}
+      {% include '_flash_messages.html' %}
 
     <h4><a href="{{ url_for('admin.admin_index') }}">Admin</a>&nbsp;&raquo;&nbsp;
         <a href="{{ url_for('admin.destinations_list') }}">Destinations</a>&nbsp;&raquo;&nbsp;

--- a/app/templates/admin/destinations/list.html
+++ b/app/templates/admin/destinations/list.html
@@ -4,6 +4,7 @@
 {% block site %}
 <div class="content">
     <div class="fullscreen">
+    {% include '_flash_messages.html' %}
     <h4><a href="{{ url_for('admin.admin_index') }}">Admin</a>&nbsp;&raquo;&nbsp;
         Destinations
     </h4>

--- a/app/templates/admin/users/list.html
+++ b/app/templates/admin/users/list.html
@@ -4,6 +4,8 @@
 {% block site %}
 <div class="content">
     <div class="fullscreen">
+        {% include '_flash_messages.html' %}
+
     <h4><a href="{{ url_for('admin.admin_index') }}">Admin</a>&nbsp;&raquo;&nbsp;
         Users
     </h4>

--- a/app/templates/admin/users/show.html
+++ b/app/templates/admin/users/show.html
@@ -11,15 +11,7 @@
     </h4>
     <h1>{{ user.name or 'Unnamed User' }}</h1>
 
-{%- with messages = get_flashed_messages(with_categories=True) %}
-{%- if messages %}
-<div class="error-messages">
-    {% for cat, msg in messages %}
-    <div class="message {{ cat }}">{{ msg }}</div>
-    {% endfor %}
-</div>
-{%- endif %}
-{%- endwith %}
+    {% include '_flash_messages.html' %}
 
 <dl class="dl-horizontal">
     <dt>Created At</dt>

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -6,15 +6,7 @@
 <div class="content">
 
     <div class="fullscreen">
-        {%- with messages = get_flashed_messages(with_categories=True) %}
-        {%- if messages %}
-        <div class="error-messages">
-            {% for cat, msg in messages %}
-            <div class="message {{ cat }}">{{ msg }}</div>
-            {% endfor %}
-        </div>
-        {%- endif %}
-        {%- endwith %}
+        {% include '_flash_messages.html' %}
         <div class="interstitial-page">
             <h1>Log in to continue</h1>
             <p>Please verify your identity by logging in using one of the services below. We use your login to confirm your identity, and verify your email address. For more info, check out our <a href="{{ config.get('BRANDING_PRIVACY_URL') }}">privacy policy</a>.</p>

--- a/app/templates/carpools/add_driver.html
+++ b/app/templates/carpools/add_driver.html
@@ -81,15 +81,7 @@ function localInitMap() {
 
 {% block site %}
 <div class="fullscreen">
-    {%- with messages = get_flashed_messages(with_categories=True) %}
-    {%- if messages %}
-    <div class="error-messages">
-        {% for cat, msg in messages %}
-        <div class="message {{ cat }}">{{ msg }}</div>
-        {% endfor %}
-    </div>
-    {%- endif %}
-    {%- endwith %}
+    {% include '_flash_messages.html' %}
 
     <form method="post" class="form-page" id="new-carpool-form">
         {{ form.hidden_tag() }}

--- a/app/templates/carpools/add_rider.html
+++ b/app/templates/carpools/add_rider.html
@@ -5,16 +5,7 @@
 <div class="content">
 
     <div class="fullscreen">
-
-        {%- with messages = get_flashed_messages(with_categories=True) %}
-        {%- if messages %}
-        <div class="error-messages">
-            {% for cat, msg in messages %}
-            <div class="message {{ cat }}">{{ msg }}</div>
-            {% endfor %}
-        </div>
-        {%- endif %}
-        {%- endwith %}
+        {% include '_flash_messages.html' %}
 
         <form method='post' class="form-page" id="join-carpool-form">
             {{ form.hidden_tag() }}

--- a/app/templates/carpools/edit.html
+++ b/app/templates/carpools/edit.html
@@ -85,16 +85,7 @@ function localInitMap() {
 {% endblock %}
 
 {% block site %}
-<div class="fullscreen">
-    {%- with messages = get_flashed_messages(with_categories=True) %}
-    {%- if messages %}
-    <div class="error-messages">
-        {% for cat, msg in messages %}
-        <div class="message {{ cat }}">{{ msg }}</div>
-        {% endfor %}
-    </div>
-    {%- endif %}
-    {%- endwith %}
+    {% include '_flash_messages.html' %}
 
     <form method="post" class="form-page" id="update-carpool-form">
         {{ form.hidden_tag() }}

--- a/app/templates/carpools/mine.html
+++ b/app/templates/carpools/mine.html
@@ -5,6 +5,8 @@
 
 <div class="content">
     <div class="fullscreen">
+        {% include '_flash_messages.html' %}
+
         <div class="form-page my-rides">
             <div class="carpools future">
                 <div class="row">

--- a/app/templates/carpools/mine.html
+++ b/app/templates/carpools/mine.html
@@ -24,6 +24,13 @@
                         <a href="{{ url_for('carpool.details', uuid=pool.uuid) }}">{{ pool.from_place }} to {{ pool.destination.name }}</a>
                     </h3>
 
+                {% if pool.canceled %}
+                    <p class="message error">This carpool has been canceled.</p>
+                    {% if pool.cancel_reason %}
+                      <p>Reason for cancellation: {{ pool.cancel_reason }}</p>
+                    {%- endif %}
+                {% endif %}
+
                 {% set current_user_ride_request = current_user.get_ride_request_in_carpool(pool) %}
                 {% if current_user_ride_request %}
                     {% if current_user_ride_request.status == 'approved'  %}
@@ -40,8 +47,10 @@
                     {% if current_user.is_driver(pool) %}
                     <div class="buttons">
                         <a class="btn btn-primary" href="{{ url_for('carpool.details', uuid=pool.uuid) }}">View details</a>
-                        <a class="btn btn-primary" href="{{ url_for('carpool.edit', uuid=pool.uuid) }}">Edit your carpool</a>
-                        <a class="btn btn-danger" href="{{ url_for('carpool.cancel', uuid=pool.uuid) }}">Cancel your carpool</a>
+                        {% if not pool.canceled %}
+                            <a class="btn btn-primary" href="{{ url_for('carpool.edit', uuid=pool.uuid) }}">Edit your carpool</a>
+                            <a class="btn btn-danger" href="{{ url_for('carpool.cancel', uuid=pool.uuid) }}">Cancel your carpool</a>
+                        {% endif %}
                     </div>
                     <p class="message success">You’re the driver of this carpool. Thanks for driving!</p>
 

--- a/app/templates/carpools/show.html
+++ b/app/templates/carpools/show.html
@@ -5,15 +5,7 @@
 <div class="content carpool-detail">
 
     <div class="fullscreen">
-        {%- with messages = get_flashed_messages(with_categories=True) %}
-        {%- if messages %}
-        <div class="error-messages">
-            {% for cat, msg in messages %}
-            <div class="message {{ cat }}">{{ msg }}</div>
-            {% endfor %}
-        </div>
-        {%- endif %}
-        {%- endwith %}
+        {% include '_flash_messages.html' %}
 
         <div class="form-page">
 

--- a/app/templates/carpools/show.html
+++ b/app/templates/carpools/show.html
@@ -15,10 +15,17 @@
                 <h3>This carpool has left!</h3>
             {%- endif %}
 
+	          {% if pool.canceled %}
+                <p class="message error">This carpool has been canceled!</p>
+                {% if pool.cancel_reason %}
+                    <p>Reason for cancellation: {{ pool.cancel_reason }}</p>
+                {%- endif %}
+            {%- endif %}
+
         {% set current_user_ride_request = current_user.get_ride_request_in_carpool(pool) %}
         {% set show_request_cancel_buttons = False %}
 
-        {% if pool.future or current_user_ride_request.status == 'approved' or current_user.is_driver(pool) %}
+        {% if (pool.future and not pool.canceled) or current_user_ride_request.status == 'approved' or current_user.is_driver(pool) %}
             {% if current_user_ride_request and current_user_ride_request.status == 'approved'  %}
 
             <div class="two-col-layout">
@@ -66,10 +73,12 @@
                         </p>
                         {% endif %}
                 </div>
+                {% if not pool.canceled %}
                 <div class="two-col-column">
                     <a class="btn btn-primary" href="{{ url_for('carpool.edit', uuid=pool.uuid) }}">Edit your carpool</a>
                     <a class="btn btn-danger" href="{{ url_for('carpool.cancel', uuid=pool.uuid) }}">Cancel this carpool</a>
                 </div>
+                {% endif %}
             </div>
 
             {% if pool.get_ride_requests_query().count() %}

--- a/app/templates/destinations/show.html
+++ b/app/templates/destinations/show.html
@@ -5,15 +5,7 @@
 <div class="content">
 
     <div class="fullscreen">
-        {%- with messages = get_flashed_messages(with_categories=True) %}
-        {%- if messages %}
-        <div class="error-messages">
-            {% for cat, msg in messages %}
-            <div class="message {{ cat }}">{{ msg }}</div>
-            {% endfor %}
-        </div>
-        {%- endif %}
-        {%- endwith %}
+        {% include '_flash_messages.html' %}
 
         <div class="form-page">
 

--- a/app/templates/profiles/show.html
+++ b/app/templates/profiles/show.html
@@ -25,15 +25,7 @@
 <div class="content">
 
     <div class="fullscreen">
-        {%- with messages = get_flashed_messages(with_categories=True) %}
-        {%- if messages %}
-        <div class="error-messages">
-            {% for cat, msg in messages %}
-            <div class="message {{ cat }}">{{ msg }}</div>
-            {% endfor %}
-        </div>
-        {%- endif %}
-        {%- endwith %}
+        {% include '_flash_messages.html' %}
 
         <form method="post" class="form-page" id="update-profile-form">
             {{ form.hidden_tag() }}

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -8,6 +8,8 @@
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
 
+# path to migration scripts
+script_location = .
 
 # Logging configuration
 [loggers]

--- a/migrations/versions/1c16c79d5f85_add_canceled_column_to_carpools.py
+++ b/migrations/versions/1c16c79d5f85_add_canceled_column_to_carpools.py
@@ -1,0 +1,28 @@
+"""add canceled column to carpools
+
+Revision ID: 1c16c79d5f85
+Revises: 0dad6c8372e4
+Create Date: 2018-09-04 23:19:02.950009
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1c16c79d5f85'
+down_revision = '0dad6c8372e4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('carpools', sa.Column('canceled', sa.Boolean(), nullable=True, server_default=sa.schema.DefaultClause("0")))
+    op.add_column('carpools', sa.Column('cancel_reason', sa.String(), nullable=True))
+    op.create_index(op.f('ix_carpools_canceled'), 'carpools', ['canceled'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_carpools_canceled'), table_name='carpools')
+    op.drop_column('carpools', 'canceled')
+    op.drop_column('carpools', 'cancel_reason')


### PR DESCRIPTION
Fixes #199.
Fixes #650.

Changes made:
* Add `canceled` and `cancel_reason` columns to `carpools` table
* Show cancellation notice on carpool detail page if carpool has been canceled
* Hide "edit", "cancel", and "request seat" buttons when carpool is canceled
* Do not show canceled carpools on the "Find a ride" page
* Show canceled carpools on "My Rides" page, with the cancellation notice.
* Refactor the flash message display code into a separate template file which can be included on any page