### PR TITLE
If we don't get a name from Google oauth, we pretend it is an empty string

### DIFF
--- a/app/auth/oauth.py
+++ b/app/auth/oauth.py
@@ -101,8 +101,11 @@ class GoogleSignIn(OAuthSignIn):
         )
         me = oauth_session.get('').json()
 
-        if 'sub' not in me:
+        # If the dict is not well-formed, we either error or form it properly.
+        if 'sub' not in me or 'email' not in me:
             raise ValueError("Error with OAuth callback: {}".format(me))
+        if 'name' not in me:
+            me['name'] = ''
 
         return (
             'google$' + me['sub'],


### PR DESCRIPTION
Fixes part of #667 - the Google OAuth error is caused by the `name` field not being present in the dictionary.  

This PR adds that field if it is missing, and requires that the `email` field be set.

This PR does _not_ fix the fact that Sentry is not configured, as per @iandees:  `Then sentry.captureException is called but Sentry isn't configured so it throws a 500`

cc @iandees, @jillh510.