### PR TITLE
#675: Show carpool departure weekday and time in /carpools/find list

### DIFF
--- a/app/carpool/views.py
+++ b/app/carpool/views.py
@@ -146,7 +146,7 @@ def start_geojson():
                 'seats_available': pool.seats_available,
                 'leave_time': pool.leave_time.isoformat(),
                 'return_time': pool.return_time.isoformat(),
-                'leave_time_human': pool.leave_time_formatted,
+                'leave_time_human': pool.leave_time.strftime(dt_format),
                 'return_time_human': pool.return_time.strftime(dt_format),
                 'driver_gender': escape(pool.driver.gender),
                 'is_approximate_location': is_approximate_location,


### PR DESCRIPTION
Fixes #675 

- The departure time (`leave_time_human`) was previously invoking a method `leave_time_formatted`, which in turn used the environment var `DATE_FORMAT_SHORT` to format the date.
- This PR switches `leave_time_human` on the `/carpools/find` page to format the datetime directly and use the longer `DATE_FORMAT` environment var, the same as the return time.