### PR TITLE
Reworking Sentry config for better reporting

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -55,12 +55,20 @@ def create_app(config_name):
         app.logger.info("Using Sentry")
         sentry = Sentry(app)
 
+    @app.context_processor
+    def sentry_variables():
+        return dict(
+            public_dsn=sentry.client.get_public_dsn(
+                'https') if sentry else None,
+            sentry_env=app.config.get('SENTRY_ENVIRONMENT'),
+            sentry_commit_hash=app.config.get('SENTRY_COMMIT_HASH'),
+        )
+
     @app.errorhandler(500)
     def internal_server_error(error):
         return render_template(
             '500.html',
             event_id=g.sentry_event_id,
-            public_dsn=sentry.client.get_public_dsn('https') if sentry else None
         ), 500
 
     @app.errorhandler(400)

--- a/app/config.py
+++ b/app/config.py
@@ -33,7 +33,7 @@ class Config:
     DEBUG = os.environ.get('FLASK_DEBUG', False)
     VERBOSE_SQLALCHEMY = False
     SSLIFY_ENABLE = False
-    SENTRY_ENABLE = False
+    SENTRY_ENABLE = os.environ.get('SENTRY_ENABLE')
     GOOGLE_MAPS_API_KEY = os.environ.get('GOOGLE_MAPS_API_KEY')
     INTERCOM_KEY = os.environ.get('INTERCOM_KEY')
     GOOGLE_ANALYTICS_ID = os.environ.get('GOOGLE_ANALYTICS_ID')

--- a/app/config.py
+++ b/app/config.py
@@ -76,10 +76,12 @@ class Config:
     USE_SESSION_FOR_NEXT = True
 
     SENTRY_DSN = os.environ.get('SENTRY_DSN')
+    SENTRY_ENVIRONMENT = os.environ.get('CARPOOL_ENV') or 'Unknown'
+    SENTRY_COMMIT_HASH = get_git_sha()
     SENTRY_CONFIG = {
         'dsn': SENTRY_DSN,
-        'release': get_git_sha(),
-        'environment': os.environ.get('CARPOOL_ENV') or 'Unknown',
+        'release': SENTRY_COMMIT_HASH,
+        'environment': SENTRY_ENVIRONMENT,
     }
 
     DATE_FORMAT = os.environ.get('DATE_FORMAT', '%a %b %-d %Y at %-I:%M %p')

--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,7 @@
 import os
 
+import raven
+
 
 def int_env(key, default):
     """ Handle empty values for environment variables
@@ -10,6 +12,15 @@ def int_env(key, default):
         return int(default)
 
     return int(val)
+
+
+def get_git_sha():
+    try:
+        return raven.fetch_git_sha(os.path.dirname(os.path.dirname(__file__)))
+    except Exception as e:
+        print(e)
+        pass
+    return os.environ.get('HEROKU_SLUG_COMMIT')
 
 
 class Config:
@@ -65,6 +76,11 @@ class Config:
     USE_SESSION_FOR_NEXT = True
 
     SENTRY_DSN = os.environ.get('SENTRY_DSN')
+    SENTRY_CONFIG = {
+        'dsn': SENTRY_DSN,
+        'release': get_git_sha(),
+        'environment': os.environ.get('CARPOOL_ENV') or 'Unknown',
+    }
 
     DATE_FORMAT = os.environ.get('DATE_FORMAT', '%a %b %-d %Y at %-I:%M %p')
     DATE_FORMAT_SHORT = os.environ.get('DATE_FORMAT_SHORT', '%B %-d, %Y')

--- a/app/templates/500.html
+++ b/app/templates/500.html
@@ -20,13 +20,4 @@
 
 </div>
 
-{% if event_id %}
-<script>
-Raven.showReportDialog({
-    eventId: '{{ event_id }}',
-    dsn: '{{ public_dsn }}'
-});
-</script>
-{% endif %}
-
 {% endblock %}

--- a/app/templates/_template.html
+++ b/app/templates/_template.html
@@ -214,5 +214,21 @@ function doLogout() {
 {% block site %}{% endblock %}
 <!--Zendesk support widget-->
 <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=19972695-e94b-40d7-be27-3f1c22dc0bc5"> </script>
+{% if public_dsn %}
+<!-- Sentry error reporting -->
+<script src="https://browser.sentry-cdn.com/4.0.5/bundle.min.js" integrity="sha384-GBuMTYSVbNX2T8znvVCZnO4rc/izXyS4EMzltAUjjio037UxfHsgG/QoufqAY8mS" crossorigin="anonymous"></script>
+<script>
+  (function() {
+    'use strict';
+    window.Sentry.init(
+      {
+        'dsn': '{{ public_dsn }}',
+        'release': '{{ sentry_commit_hash }}',
+        'environment': '{{ sentry_env }}'
+      }
+    );
+  })();
+</script>
+{% endif %}
 
 {%- endblock %}


### PR DESCRIPTION
These changes accomplish the following:

1. Consolidate Sentry reporting into a single Sentry project with multiple environments
2. Tag Sentry errors with the git hash of the codebase when the error happened (helps us identify regressions)
3. Enable client-side reporting for JavaScript errors

Closes #686 
Fixes #673 