### PR TITLE
add a demo config so we can have a demo CARPOOL_ENV

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -162,6 +162,6 @@ config = {
     'testing': TestingConfig,
     'staging': StagingConfig,
     'production': ProductionConfig,
-
+    'demo': ProductionConfig,
     'default': DevelopmentConfig
 }


### PR DESCRIPTION
Should have done this with #687 but didn't occur to me then. This lets us set CARPOOL_ENV to `demo` so that we can use this for the Sentry environment config option.