### PR TITLE
#696: Layout fixes on carpool edit page

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -641,7 +641,7 @@ pre.text {
 @media screen and (max-width:980px) {
 	.fullscreen {
 		width: 100%;
-		padding: 0 20px 50px 20px;
+		padding: 0 20px 70px 20px;
 	}
 	.carpool-results h1 {
 		margin-top: 10px;

--- a/app/templates/carpools/edit.html
+++ b/app/templates/carpools/edit.html
@@ -85,6 +85,7 @@ function localInitMap() {
 {% endblock %}
 
 {% block site %}
+<div class="fullscreen">
     {% include '_flash_messages.html' %}
 
     <form method="post" class="form-page" id="update-carpool-form">


### PR DESCRIPTION
Fixes #696 

* Added missing `div` tag to Carpool edit page
* Added extra padding to the bottom of the "fullscreen" div to allow mobile devices to scroll further. This keeps the "Help" button from getting in the way of other content like right-aligned buttons.