### PR TITLE
651: Change circle marker size on map; fix map bugs

### DIFF
--- a/app/carpool/views.py
+++ b/app/carpool/views.py
@@ -64,8 +64,8 @@ def approximate_location(geometry):
     # 'coordinates': [-121.88632860000001, 37.3382082]
     coord = geometry['coordinates']
     geometry['coordinates'] = [
-        coord[0] + random.uniform(-.02, .02),
-        coord[1] + random.uniform(-.02, .02),
+        round(coord[0], 2) + random.uniform(-.005, .005),
+        round(coord[1], 2) + random.uniform(-.005, .005),
     ]
     return geometry
 
@@ -115,6 +115,7 @@ def start_geojson():
         for ride in rides:
             confirmed_carpools.append(ride.carpool_id)
     else:
+        # anonymous user can only see 3 results
         pools = pools.limit(3)
 
     for pool in pools:

--- a/app/static/js/find.js
+++ b/app/static/js/find.js
@@ -290,10 +290,10 @@ function mapDataCallback(features) {
                         strokeWeight: 0
                     },
                     draggable: false,
-                    map: map
+                    map: map,
+                    url: feature.getId(),
                 });
                 marker.addListener('click', function() {
-                    console.log('click marker', this);
                     window.location.href = this.url;
                 });
                 feature.marker = marker;

--- a/app/static/js/find.js
+++ b/app/static/js/find.js
@@ -9,6 +9,8 @@ const geocodeParams = { componentRestrictions: { country: 'US' } };
 const carpoolDistance = {};
 // list of all geoJSON features
 let carpoolFeatures = [];
+// list of the markers currently appearing on the map
+let markers = [];
 
 /* eslint no-use-before-define: 0 */ // no-undef
 /* eslint no-console: 0 */
@@ -83,7 +85,6 @@ function localInitMap() {  // eslint-disable-line no-unused-vars
             const lng = parseFloat(lonStr);
             setLatLng(lat, lng);
         } catch (e) {
-            console.log('no lat/lng');
         }
     });
 }
@@ -91,7 +92,6 @@ function localInitMap() {  // eslint-disable-line no-unused-vars
 function geoSuccess(position) {
     // zoom to user position if/when they allow location access
     const coords = position.coords;
-    console.log('event: browser geolocation', coords);
     setLatLng(coords.latitude, coords.longitude);
     zoomMap();
 }
@@ -103,6 +103,10 @@ function doSearch() {
     map.data.forEach(function(feature) {
         map.data.remove(feature);
     });
+    for (let i = 0; i < markers.length; i++) {
+        markers[i].setMap(null);
+    }
+    markers = [];
 
     const params = '?near.lat=' + nearLatLon.lat + '&near.lon=' + nearLatLon.lng;
 
@@ -276,19 +280,24 @@ function mapDataCallback(features) {
         map.data.setStyle(function(feature) {
             if (feature.getProperty('is_approximate_location')) {
                 var geo = feature.getGeometry();
-                const circle = new google.maps.Circle({
-                    map: map,
-                    center: geo.get(),
-                    radius: 1800,
-                    fillColor: '#3090C7',
-                    fillOpacity: 0.5,
-                    strokeWeight: 0,
-                    url: feature.getId(),
+                var marker = new google.maps.Marker({
+                    position: geo.get(),
+                    icon: {
+                        path: google.maps.SymbolPath.CIRCLE,
+                        fillColor: '#3090C7',
+                        fillOpacity: 0.5,
+                        scale: 25,
+                        strokeWeight: 0
+                    },
+                    draggable: false,
+                    map: map
                 });
-                circle.addListener('click', function() {
+                marker.addListener('click', function() {
+                    console.log('click marker', this);
                     window.location.href = this.url;
                 });
-                feature.circle = circle;
+                feature.marker = marker;
+                markers.push(marker);
                 return { visible: false };
             } else {
                 return {


### PR DESCRIPTION
Fixes #651 

Changes:
* Use a circle-shaped "Marker" instead of a circle "Shape" to indicate approximate carpool location. This will not change pixel size when zooming.
* Fix a bug where old markers wouldn't disappear from the map when you searched again. (If you searched the same city several times in a row, this could result in a screen full of markers)
* Tweak the "approximate location" algorithm to reduce randomness. Random location was causing the markers to jump around if you searched the same area multiple times. Adjusted to round off the lat/long coords, then apply a small random variation.

**Who these changes apply to:**
These changes only apply in the situations where the user sees the approximate location. This happens in the following scenarios:
* anonymous user
* authenticated user viewing a carpool where they aren't the driver or an approved passenger

**What didn't change:**
In the other use cases, a pin-shaped marker icon appears at the exact location. (As before; this PR doesn't change that behavior.) These include:
* Driver sees their own carpool on the map
* Approved passenger sees the carpool on the map when they're on the passenger list