### PR TITLE
Show same information for the "My rides" page and the details page

### DIFF
--- a/app/templates/carpools/mine.html
+++ b/app/templates/carpools/mine.html
@@ -83,13 +83,17 @@
                     </div>
 
                     <div class="two-col-layout">
+                        {% if current_user.is_driver(pool) or (current_user_ride_request and current_user_ride_request.status == 'approved') or current_user_ride_request %}
                         <div class="two-col-column">
                             <h4>Carpool Details</h4>
-                            {% if current_user.is_driver(pool) or current_user_ride_request and current_user_ride_request.status == 'approved' %}
-                                <p>Driver: {{ pool.driver.name }} ({{ pool.driver.gender_string() }})</p>
-                                <p>Vehicle: {{ pool.vehicle_description or "(None supplied)" }}</p>
-                            {%- endif %}
+                            {% if current_user_ride_request and current_user_ride_request.status != 'approved' %}
+                            <p>Driver Gender: {{ pool.driver.gender_string() }}</p>
+                            {% else %}
+                            <p>Driver: {{ pool.driver.name }} ({{ pool.driver.gender_string() }})</p>
+                            <p>Vehicle: {{ pool.vehicle_description or "(None supplied)" }}</p>
+                            {% endif %}
                         </div>
+                        {% endif %}
                         <div class="two-col-column">
                             <h4>Additional notes</h4>
                             <p>{{ pool.notes or "(None supplied)"}}</p>

--- a/app/templates/carpools/mine.html
+++ b/app/templates/carpools/mine.html
@@ -83,7 +83,7 @@
                     </div>
 
                     <div class="two-col-layout">
-                        {% if current_user.is_driver(pool) or (current_user_ride_request and current_user_ride_request.status == 'approved') or current_user_ride_request %}
+                        {% if current_user.is_driver(pool) or (current_user_ride_request and current_user_ride_request.status != 'denied') %}
                         <div class="two-col-column">
                             <h4>Carpool Details</h4>
                             {% if current_user_ride_request and current_user_ride_request.status != 'approved' %}

--- a/app/templates/carpools/show.html
+++ b/app/templates/carpools/show.html
@@ -180,7 +180,7 @@
             </div>
 
             <div class="two-col-layout">
-                {% if current_user.is_driver(pool) or (current_user_ride_request and current_user_ride_request.status == 'approved') or current_user_ride_request %}
+                {% if current_user.is_driver(pool) or (current_user_ride_request and current_user_ride_request != 'denied') %}
                 <div class="two-col-column">
                     <h4>Carpool Details</h4>
                     {% if current_user_ride_request and current_user_ride_request.status != 'approved' %}
@@ -191,12 +191,10 @@
                     {% endif %}
                 </div>
                 {% endif %}
-                {% if pool.notes %}
                 <div class="two-col-column">
                     <h4>Additional notes</h4>
-                    <p>{{ pool.notes }}</p>
+                    <p>{{ pool.notes or "(None supplied)"}}</p>
                 </div>
-                {% endif %}
                 <div class="two-col-column">
                     <h4>Link to this carpool</h4>
                     <p><a href="{{ request.url }}">{{ request.url }}</a></p>

--- a/app/templates/carpools/show.html
+++ b/app/templates/carpools/show.html
@@ -183,7 +183,7 @@
                 {% if current_user.is_driver(pool) or (current_user_ride_request and current_user_ride_request.status == 'approved') or current_user_ride_request %}
                 <div class="two-col-column">
                     <h4>Carpool Details</h4>
-                    {% if current_user_ride_request %}
+                    {% if current_user_ride_request and current_user_ride_request.status != 'approved' %}
                     <p>Driver Gender: {{ pool.driver.gender_string() }}</p>
                     {% else %}
                     <p>Driver: {{ pool.driver.name }} ({{ pool.driver.gender_string() }})</p>

--- a/app/templates/carpools/show.html
+++ b/app/templates/carpools/show.html
@@ -180,7 +180,7 @@
             </div>
 
             <div class="two-col-layout">
-                {% if current_user.is_driver(pool) or (current_user_ride_request and current_user_ride_request != 'denied') %}
+                {% if current_user.is_driver(pool) or (current_user_ride_request and current_user_ride_request.status != 'denied') %}
                 <div class="two-col-column">
                     <h4>Carpool Details</h4>
                     {% if current_user_ride_request and current_user_ride_request.status != 'approved' %}


### PR DESCRIPTION
Unifies the display of the "My rides" page and the carpool details page. I'm not sure exactly if this is the combination of things that is desired, but I went off of what I thought the existing layout probably meant to show.

Not signed up:
![image](https://user-images.githubusercontent.com/10186337/46589008-c329d980-ca59-11e8-8512-bd86259d5f91.png)

Requested but not confirmed:
![image](https://user-images.githubusercontent.com/10186337/46589324-3c76fb80-ca5d-11e8-81a2-377d7b73df3b.png)

Requested and approved:
![image](https://user-images.githubusercontent.com/10186337/46589330-51ec2580-ca5d-11e8-8825-07d99477ac74.png)

Requested and denied:
![image](https://user-images.githubusercontent.com/10186337/46589370-cde66d80-ca5d-11e8-86b8-1b6b2ae0de96.png)