### PR TITLE
use SERVER_NAME env variable for Sentry config

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -82,6 +82,7 @@ class Config:
         'dsn': SENTRY_DSN,
         'release': SENTRY_COMMIT_HASH,
         'environment': SENTRY_ENVIRONMENT,
+        'name': os.environ.get('SERVER_NAME') or 'Unknown',
     }
 
     DATE_FORMAT = os.environ.get('DATE_FORMAT', '%a %b %-d %Y at %-I:%M %p')


### PR DESCRIPTION
This is a config only change that sets the server name property for Sentry so we can filter errors by domain.