### PR TITLE
Don't call a function that doesn't exist

### DIFF
--- a/app/templates/_template.html
+++ b/app/templates/_template.html
@@ -59,7 +59,6 @@ function initMap() {
       if (location.href.indexOf($('#ride-select-form').attr('action')) >= 0) {
         // if on find page already, re-order and re-zoom
         setLatLng(loc.lat(), loc.lng());
-        sortDOMResults();
       } else {
         // go to find/give with lat/lng params
         $('.ride-form input[name="lat"]').val(loc.lat());


### PR DESCRIPTION
The `sortDOMResults()` function is not defined anywhere, so rather than breaking the page I'm deleting it.

This is related to https://sentry.ragtag.org/ragtag/nomad-prod/issues/156/