### PR TITLE
Wrapping find.js and script.js in IIFE

### DIFF
--- a/app/static/js/find.js
+++ b/app/static/js/find.js
@@ -1,336 +1,342 @@
-let geocoder;
-const defaultLat = 38.518;
-const defaultLon = -97.328;
-// geocoded from userQuery: { lat: 38, lng: -97 }
-const nearLatLon = {};
-// restrict results to US
-const geocodeParams = { componentRestrictions: { country: 'US' } };
-// { featureId: val }
-const carpoolDistance = {};
-// list of all geoJSON features
-let carpoolFeatures = [];
-// list of the markers currently appearing on the map
-let markers = [];
+(function() {
+  // Exposing these functions that need to be globally available up top
+  window.setLatLng = setLatLng;
+  window.localInitMap = localInitMap;
 
-/* eslint no-use-before-define: 0 */ // no-undef
-/* eslint no-console: 0 */
-/* global $: false, geoJSONUrl: false, google: false, map: true, mapStyleDiscreet: false, newCarpoolUrl: false, userLatLon: false, userQuery: true */
+  let geocoder;
+  const defaultLat = 38.518;
+  const defaultLon = -97.328;
+  // geocoded from userQuery: { lat: 38, lng: -97 }
+  const nearLatLon = {};
+  // restrict results to US
+  const geocodeParams = { componentRestrictions: { country: 'US' } };
+  // { featureId: val }
+  const carpoolDistance = {};
+  // list of all geoJSON features
+  let carpoolFeatures = [];
+  // list of the markers currently appearing on the map
+  let markers = [];
 
-/*
-    externally defined globals
-      geoJSONUrl - URL to get carpool list GeoJSON
-      map - Google Map object
-      mapStyleDiscreet - defined in static/js/map-styles.js
-      newCarpoolUrl - URL to create new carpool
-      userQuery - sanitized user query string
-*/
+  /* eslint no-use-before-define: 0 */ // no-undef
+  /* eslint no-console: 0 */
+  /* global $: false, geoJSONUrl: false, google: false, map: true, mapStyleDiscreet: false, newCarpoolUrl: false, userLatLon: false, userQuery: true */
 
-// zoom to user location only if no query in URL
-if (!userQuery && !userLatLon.lat && navigator.geolocation) {
-    navigator.geolocation.getCurrentPosition(geoSuccess);
-}
+  /*
+      externally defined globals
+        geoJSONUrl - URL to get carpool list GeoJSON
+        map - Google Map object
+        mapStyleDiscreet - defined in static/js/map-styles.js
+        newCarpoolUrl - URL to create new carpool
+        userQuery - sanitized user query string
+  */
 
-function setLatLng(lat, lng) {
-    nearLatLon.lat = lat;
-    nearLatLon.lng = lng;
-    doSearch();
-}
+  // zoom to user location only if no query in URL
+  if (!userQuery && !userLatLon.lat && navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(geoSuccess);
+  }
 
-function localInitMap() {  // eslint-disable-line no-unused-vars
-    // called from _template.html callback when Google Maps API loads
-    map = new google.maps.Map(document.getElementById('background-map'), {
-        center: { lat: defaultLat, lng: defaultLon },
-        zoom: userQuery ? 11 : 3,
-        styles: mapStyleDiscreet
-    });
-    geocoder = new google.maps.Geocoder();
-    if (userLatLon.lat) {
-        setLatLng(userLatLon.lat, userLatLon.lng);
-        // ignore query if already have lat/lng
-        userQuery = null;
-    } else if (userQuery) {
-        geocode(userQuery);
-    } else {
-        // no location available = no results
-        showNoQuery();
-    }
-    // don't reload page; just update sort and map
-    $('.ride-form').submit(function (ev) {
-        ev.preventDefault();
-        const input = $('.ride-form .location-input');
+  function setLatLng(lat, lng) {
+      nearLatLon.lat = lat;
+      nearLatLon.lng = lng;
+      doSearch();
+  }
 
-        if (!input) {
-            return;  // no user input; don't search
-        }
+  function localInitMap() {  // eslint-disable-line no-unused-vars
+      // called from _template.html callback when Google Maps API loads
+      map = new google.maps.Map(document.getElementById('background-map'), {
+          center: { lat: defaultLat, lng: defaultLon },
+          zoom: userQuery ? 11 : 3,
+          styles: mapStyleDiscreet
+      });
+      geocoder = new google.maps.Geocoder();
+      if (userLatLon.lat) {
+          setLatLng(userLatLon.lat, userLatLon.lng);
+          // ignore query if already have lat/lng
+          userQuery = null;
+      } else if (userQuery) {
+          geocode(userQuery);
+      } else {
+          // no location available = no results
+          showNoQuery();
+      }
+      // don't reload page; just update sort and map
+      $('.ride-form').submit(function (ev) {
+          ev.preventDefault();
+          const input = $('.ride-form .location-input');
 
-        const latStr = $('.ride-form input[name="lat"]').val();
-        const lonStr = $('.ride-form input[name="lon"]').val();
-        if (!latStr || !lonStr) {
-            // no result: geocode the first suggestion if there is one
-            let query = '';
-            if ($('.pac-container .pac-item:first').length) {
-                $('.pac-container .pac-item:first').children().each(function () {
-                    query += $(this).text() + ' ';
-                });
-            } else {
-                // otherwise geocode user input
-                query = input.text().trim();
-            }
-            userQuery = query;
-            return geocode(query);
-        }
+          if (!input) {
+              return;  // no user input; don't search
+          }
 
-        try {
-            const lat = parseFloat(latStr);
-            const lng = parseFloat(lonStr);
-            setLatLng(lat, lng);
-        } catch (e) {
-        }
-    });
-}
+          const latStr = $('.ride-form input[name="lat"]').val();
+          const lonStr = $('.ride-form input[name="lon"]').val();
+          if (!latStr || !lonStr) {
+              // no result: geocode the first suggestion if there is one
+              let query = '';
+              if ($('.pac-container .pac-item:first').length) {
+                  $('.pac-container .pac-item:first').children().each(function () {
+                      query += $(this).text() + ' ';
+                  });
+              } else {
+                  // otherwise geocode user input
+                  query = input.text().trim();
+              }
+              userQuery = query;
+              return geocode(query);
+          }
 
-function geoSuccess(position) {
-    // zoom to user position if/when they allow location access
-    const coords = position.coords;
-    setLatLng(coords.latitude, coords.longitude);
-    zoomMap();
-}
+          try {
+              const lat = parseFloat(latStr);
+              const lng = parseFloat(lonStr);
+              setLatLng(lat, lng);
+          } catch (e) {
+          }
+      });
+  }
 
-function doSearch() {
-    // get all carpool results as GeoJSON
-    var results = $('#search-results');
-    results.empty();
-    map.data.forEach(function(feature) {
-        map.data.remove(feature);
-    });
-    for (let i = 0; i < markers.length; i++) {
-        markers[i].setMap(null);
-    }
-    markers = [];
+  function geoSuccess(position) {
+      // zoom to user position if/when they allow location access
+      const coords = position.coords;
+      setLatLng(coords.latitude, coords.longitude);
+      zoomMap();
+  }
 
-    const params = '?near.lat=' + nearLatLon.lat + '&near.lon=' + nearLatLon.lng;
+  function doSearch() {
+      // get all carpool results as GeoJSON
+      var results = $('#search-results');
+      results.empty();
+      map.data.forEach(function(feature) {
+          map.data.remove(feature);
+      });
+      for (let i = 0; i < markers.length; i++) {
+          markers[i].setMap(null);
+      }
+      markers = [];
 
-    map.data.loadGeoJson(geoJSONUrl + params, null, mapDataCallback);
-}
+      const params = '?near.lat=' + nearLatLon.lat + '&near.lon=' + nearLatLon.lng;
 
-function geocode(address) {
-    // get from localStorage cache if geocoded within 30d (Google limit)
-    const cache = JSON.parse(localStorage.getItem('geocode') || '{}');
-    const q = address.toLowerCase().trim();
-    // geocode = {"query": {"ts": 1534038439340, "lat": -97.328, "lng": 38.518}}
-    const ts = cache[q] ? cache[q].ts : 0;
-    const age = (new Date()).getTime() - ts;
+      map.data.loadGeoJson(geoJSONUrl + params, null, mapDataCallback);
+  }
 
-    $('.geocode-error').hide();
-    if (age < 30 * 24 * 60 * 60 * 1000) {
-        setLatLng(cache[q].lat, cache[q].lng);
-    } else {
-        geocodeParams.address = q;
-        geocoder.geocode(geocodeParams, geocodeResults);
-    }
-}
+  function geocode(address) {
+      // get from localStorage cache if geocoded within 30d (Google limit)
+      const cache = JSON.parse(localStorage.getItem('geocode') || '{}');
+      const q = address.toLowerCase().trim();
+      // geocode = {"query": {"ts": 1534038439340, "lat": -97.328, "lng": 38.518}}
+      const ts = cache[q] ? cache[q].ts : 0;
+      const age = (new Date()).getTime() - ts;
 
-function deg2rad(deg) {
-    return deg * (Math.PI / 180);
-}
+      $('.geocode-error').hide();
+      if (age < 30 * 24 * 60 * 60 * 1000) {
+          setLatLng(cache[q].lat, cache[q].lng);
+      } else {
+          geocodeParams.address = q;
+          geocoder.geocode(geocodeParams, geocodeResults);
+      }
+  }
 
-function distance(lat2, lng2) {
-    // use Haversine formula to calculate approximate distance between
-    // nearLatLon and this point
-    // https://stackoverflow.com/questions/27928/calculate-distance-between-two-latitude-longitude-points-haversine-formula
-    const lat1 = nearLatLon.lat;
-    const lng1 = nearLatLon.lng;
-    // distance in km
-    const dLat = deg2rad(lat2 - lat1);
-    const dLng = deg2rad(lng2 - lng1);
-    const a = (Math.sin(dLat / 2) * Math.sin(dLat / 2)) +
-        (Math.cos(deg2rad(lat1)) * Math.cos(deg2rad(lat2)) *
-         Math.sin(dLng / 2) * Math.sin(dLng / 2));
-    return 6371 * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-}
+  function deg2rad(deg) {
+      return deg * (Math.PI / 180);
+  }
 
-function geocodeResults(results, status) {
-    // got lat/lng for user query
-    if (status == 'OK') {
-        const location = results[0].geometry.location;
-        console.log('event: geocode result=', results[0], location.lat(), location.lng());
-        setLatLng(location.lat(), location.lng());
+  function distance(lat2, lng2) {
+      // use Haversine formula to calculate approximate distance between
+      // nearLatLon and this point
+      // https://stackoverflow.com/questions/27928/calculate-distance-between-two-latitude-longitude-points-haversine-formula
+      const lat1 = nearLatLon.lat;
+      const lng1 = nearLatLon.lng;
+      // distance in km
+      const dLat = deg2rad(lat2 - lat1);
+      const dLng = deg2rad(lng2 - lng1);
+      const a = (Math.sin(dLat / 2) * Math.sin(dLat / 2)) +
+          (Math.cos(deg2rad(lat1)) * Math.cos(deg2rad(lat2)) *
+           Math.sin(dLng / 2) * Math.sin(dLng / 2));
+      return 6371 * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  }
 
-        // save geocoding results
-        const cache = JSON.parse(localStorage.getItem('geocode') || '{}');
-        const key = userQuery.toLowerCase().trim();
-        cache[key] = {
-            ts: (new Date().getTime()),
-            lat: location.lat(),
-            lng: location.lng()
-        };
-        localStorage.setItem('geocode', JSON.stringify(cache));
-    } else {
-        // set error under input
-        $('.geocode-error').show();
-    }
-}
+  function geocodeResults(results, status) {
+      // got lat/lng for user query
+      if (status == 'OK') {
+          const location = results[0].geometry.location;
+          console.log('event: geocode result=', results[0], location.lat(), location.lng());
+          setLatLng(location.lat(), location.lng());
 
-function showCarpoolDetails(carpoolId) {
-    window.location = carpoolId;
-    return;
-}
+          // save geocoding results
+          const cache = JSON.parse(localStorage.getItem('geocode') || '{}');
+          const key = userQuery.toLowerCase().trim();
+          cache[key] = {
+              ts: (new Date().getTime()),
+              lat: location.lat(),
+              lng: location.lng()
+          };
+          localStorage.setItem('geocode', JSON.stringify(cache));
+      } else {
+          // set error under input
+          $('.geocode-error').show();
+      }
+  }
 
-function showCarpoolDetailsDivClickHandler(event) {
-    showCarpoolDetails(event.data);
-}
+  function showCarpoolDetails(carpoolId) {
+      window.location = carpoolId;
+      return;
+  }
 
-function sortFeaturesByDistance(features) {
-    // set distance from requested location
-    features.forEach(function(feature) {
-        const geo = feature.getGeometry().get();
-        // extract id from URL
-        const id = feature.getId().replace(/.*?\/carpools\/(.*)/, '$1');
-        feature.setProperty('carpoolId', id);
-        carpoolDistance[feature.getProperty('carpoolId')] = distance(geo.lat(), geo.lng());
-    });
-    // sort by distance
-    return features.sort(function(a, b) {
-        return carpoolDistance[a.getProperty('carpoolId')] - carpoolDistance[b.getProperty('carpoolId')];
-    });
-}
+  function showCarpoolDetailsDivClickHandler(event) {
+      showCarpoolDetails(event.data);
+  }
 
-function zoomMap() {
-    let features = [];
-    if (nearLatLon.lat) {
-        console.log('zooming to nearLatLon', nearLatLon);
-        // if nearLatLon, zoom to nearLatLon +- 100km or minimum 3 closest features
-        features = carpoolFeatures.slice(0, 3);
-        carpoolFeatures.slice(3).forEach(function(feature) {
-            if (carpoolDistance[feature.getId()] < 100) {
-                features.push(feature);
-            }
-        });
-    } else {
-        // else fit to all features
-        features = carpoolFeatures;
-    }
+  function sortFeaturesByDistance(features) {
+      // set distance from requested location
+      features.forEach(function(feature) {
+          const geo = feature.getGeometry().get();
+          // extract id from URL
+          const id = feature.getId().replace(/.*?\/carpools\/(.*)/, '$1');
+          feature.setProperty('carpoolId', id);
+          carpoolDistance[feature.getProperty('carpoolId')] = distance(geo.lat(), geo.lng());
+      });
+      // sort by distance
+      return features.sort(function(a, b) {
+          return carpoolDistance[a.getProperty('carpoolId')] - carpoolDistance[b.getProperty('carpoolId')];
+      });
+  }
 
-    if (!features.length) {
-        // no carpools: zoom to requested location
-        if (nearLatLon.lat) {
-            map.setCenter(new google.maps.LatLng(nearLatLon.lat, nearLatLon.lng));
-            map.setZoom(11);
-        }
-        return;
-    }
-    // fit map to set of features
-    const bounds = new google.maps.LatLngBounds();
-    features.forEach(function (feature) {
-        const geo = feature.getGeometry().get();
-        bounds.extend(new google.maps.LatLng(geo.lat(), geo.lng()));
-    });
-    if (nearLatLon.lat) {
-        // include search location
-        bounds.extend(new google.maps.LatLng(nearLatLon.lat, nearLatLon.lng));
-    }
-    map.fitBounds(bounds);
-}
+  function zoomMap() {
+      let features = [];
+      if (nearLatLon.lat) {
+          console.log('zooming to nearLatLon', nearLatLon);
+          // if nearLatLon, zoom to nearLatLon +- 100km or minimum 3 closest features
+          features = carpoolFeatures.slice(0, 3);
+          carpoolFeatures.slice(3).forEach(function(feature) {
+              if (carpoolDistance[feature.getId()] < 100) {
+                  features.push(feature);
+              }
+          });
+      } else {
+          // else fit to all features
+          features = carpoolFeatures;
+      }
 
-function showNoQuery() {
-    $('#search-results').append('<div class="result">' +
-        '<h3>Please enter a location to find a nearby ride.</h3>' +
-        '</div>');
-}
+      if (!features.length) {
+          // no carpools: zoom to requested location
+          if (nearLatLon.lat) {
+              map.setCenter(new google.maps.LatLng(nearLatLon.lat, nearLatLon.lng));
+              map.setZoom(11);
+          }
+          return;
+      }
+      // fit map to set of features
+      const bounds = new google.maps.LatLngBounds();
+      features.forEach(function (feature) {
+          const geo = feature.getGeometry().get();
+          bounds.extend(new google.maps.LatLng(geo.lat(), geo.lng()));
+      });
+      if (nearLatLon.lat) {
+          // include search location
+          bounds.extend(new google.maps.LatLng(nearLatLon.lat, nearLatLon.lng));
+      }
+      map.fitBounds(bounds);
+  }
 
-function showNoResults(text) {
-    $('#search-results').append('<div class="result">' +
-        '<h3>No carpools nearby.</h3>' +
-        '<p>Will you consider <a href="' + newCarpoolUrl + '">starting one</a>?</p>' +
-        '</div>');
-}
+  function showNoQuery() {
+      $('#search-results').append('<div class="result">' +
+          '<h3>Please enter a location to find a nearby ride.</h3>' +
+          '</div>');
+  }
 
-function showLoginPrompt(){
-    $('#search-results').append('<div style="padding-top: 20px; display: inline-flex;">' +
-        '<h3 style="margin-right: 10px; padding-top: 4px;">Log in to see more carpools</h3>' +
-        '<a href="/login"><button class="btn btn-primary">Login</button></a>' +
-        '</div>');
-}
+  function showNoResults(text) {
+      $('#search-results').append('<div class="result">' +
+          '<h3>No carpools nearby.</h3>' +
+          '<p>Will you consider <a href="' + newCarpoolUrl + '">starting one</a>?</p>' +
+          '</div>');
+  }
 
-function mapDataCallback(features) {
-    console.log('event: loaded features');
-    var results = $('#search-results');
-    results.empty();
+  function showLoginPrompt(){
+      $('#search-results').append('<div style="padding-top: 20px; display: inline-flex;">' +
+          '<h3 style="margin-right: 10px; padding-top: 4px;">Log in to see more carpools</h3>' +
+          '<a href="/login"><button class="btn btn-primary">Login</button></a>' +
+          '</div>');
+  }
 
-    if (features.length > 0) {
-        // sort by distance
-        carpoolFeatures = sortFeaturesByDistance(features);
-        for (var i = 0; i < carpoolFeatures.length; i++) {
-            const feature = features[i];
-            const geo = feature.getGeometry().get();
+  function mapDataCallback(features) {
+      console.log('event: loaded features');
+      var results = $('#search-results');
+      results.empty();
 
-            const seatsAvailable = feature.getProperty('seats_available');
-            let seatString = '<p>' + seatsAvailable + ' seats available</p>';
-            if (seatsAvailable === 1 ) {
-                seatString = '<p>' + seatsAvailable + ' seat available</p>';
-            } else if (seatsAvailable < 1) {
-                seatString = '<p>No seats available</p>';
-            }
+      if (features.length > 0) {
+          // sort by distance
+          carpoolFeatures = sortFeaturesByDistance(features);
+          for (var i = 0; i < carpoolFeatures.length; i++) {
+              const feature = features[i];
+              const geo = feature.getGeometry().get();
 
-            var resultdiv = $(
-                '<div class="result" id="' + feature.getProperty('carpoolId') + '" data-lat="' + geo.lat() + '" data-lng="' + geo.lng() + '">' +
-                    '<h3 class="result-title">' +
-                        feature.getProperty('from_place') + ' to ' + feature.getProperty('to_place') +
-                    '</h3>' + seatString +
-                    '<p>Departs: ' + feature.getProperty('leave_time_human') + '</p>' +
-                    '<p>Returns: ' + feature.getProperty('return_time_human') + '</p>' +
-                    '<p>Destination: '+ feature.getProperty('to_place') + '</p>' +
-                '</div>');
-            resultdiv.click(feature.getId(), showCarpoolDetailsDivClickHandler);
-            results.append(resultdiv);
-        }
-        map.data.setStyle(function(feature) {
-            if (feature.getProperty('is_approximate_location')) {
-                var geo = feature.getGeometry();
-                var marker = new google.maps.Marker({
-                    position: geo.get(),
-                    icon: {
-                        path: google.maps.SymbolPath.CIRCLE,
-                        fillColor: '#3090C7',
-                        fillOpacity: 0.5,
-                        scale: 25,
-                        strokeWeight: 0
-                    },
-                    draggable: false,
-                    map: map,
-                    url: feature.getId(),
-                });
-                marker.addListener('click', function() {
-                    window.location.href = this.url;
-                });
-                feature.marker = marker;
-                markers.push(marker);
-                return { visible: false };
-            } else {
-                return {
-                    icon: 'https://chart.apis.google.com/chart?chst=d_map_pin_letter&chld=%E2%80%A2|3090C7'
-                };
-            }
-        });
-        zoomMap();
-        google.maps.event.addListenerOnce(map, 'bounds_changed', function() {
-            if (this.getZoom() > 11) {
-                this.setZoom(11);
-            }
-        });
-    } else {
+              const seatsAvailable = feature.getProperty('seats_available');
+              let seatString = '<p>' + seatsAvailable + ' seats available</p>';
+              if (seatsAvailable === 1 ) {
+                  seatString = '<p>' + seatsAvailable + ' seat available</p>';
+              } else if (seatsAvailable < 1) {
+                  seatString = '<p>No seats available</p>';
+              }
 
-        zoomMap();
-        showNoResults();
-    }
+              var resultdiv = $(
+                  '<div class="result" id="' + feature.getProperty('carpoolId') + '" data-lat="' + geo.lat() + '" data-lng="' + geo.lng() + '">' +
+                      '<h3 class="result-title">' +
+                          feature.getProperty('from_place') + ' to ' + feature.getProperty('to_place') +
+                      '</h3>' + seatString +
+                      '<p>Departs: ' + feature.getProperty('leave_time_human') + '</p>' +
+                      '<p>Returns: ' + feature.getProperty('return_time_human') + '</p>' +
+                      '<p>Destination: '+ feature.getProperty('to_place') + '</p>' +
+                  '</div>');
+              resultdiv.click(feature.getId(), showCarpoolDetailsDivClickHandler);
+              results.append(resultdiv);
+          }
+          map.data.setStyle(function(feature) {
+              if (feature.getProperty('is_approximate_location')) {
+                  var geo = feature.getGeometry();
+                  var marker = new google.maps.Marker({
+                      position: geo.get(),
+                      icon: {
+                          path: google.maps.SymbolPath.CIRCLE,
+                          fillColor: '#3090C7',
+                          fillOpacity: 0.5,
+                          scale: 25,
+                          strokeWeight: 0
+                      },
+                      draggable: false,
+                      map: map,
+                      url: feature.getId(),
+                  });
+                  marker.addListener('click', function() {
+                      window.location.href = this.url;
+                  });
+                  feature.marker = marker;
+                  markers.push(marker);
+                  return { visible: false };
+              } else {
+                  return {
+                      icon: 'https://chart.apis.google.com/chart?chst=d_map_pin_letter&chld=%E2%80%A2|3090C7'
+                  };
+              }
+          });
+          zoomMap();
+          google.maps.event.addListenerOnce(map, 'bounds_changed', function() {
+              if (this.getZoom() > 11) {
+                  this.setZoom(11);
+              }
+          });
+      } else {
 
-    if (!userAuthenticated){
-        showLoginPrompt();
-    }
+          zoomMap();
+          showNoResults();
+      }
 
-    results.addClass('results-box');
+      if (!userAuthenticated){
+          showLoginPrompt();
+      }
 
-    map.data.addListener('click', function(event) {
-        showCarpoolDetails(event.feature.getId());
-    });
-}
+      results.addClass('results-box');
+
+      map.data.addListener('click', function(event) {
+          showCarpoolDetails(event.feature.getId());
+      });
+  }
+})()

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -1,163 +1,164 @@
+(function () {
+  // ======= GOOGLE MAPS ===========
 
+    // Virginia locations
+    var westva = {lat: 38.7624, lng: -79.7170677};
+    var sweetbriar = {lat: 37.5551696, lng: -79.098562};
 
+    // Baltimore locations
+    var baltLocations = [
+      {lat: 39.3146481, lng: -76.6419097},
+      {lat: 39.336027, lng: -76.574490},
+      {lat: 39.278518, lng: -76.640065},
+      {lat: 39.277858, lng: -76.542218},
+      {lat: 39.351572, lng: -76.641438}
+    ];
+    var baltCenter = {lat: 39.314246, lng: -76.601955};
+    var markers = [];
+    var mapFindRide, mapGiveRide, mapMyRides, mapMini;
 
-// ======= GOOGLE MAPS ===========
+  function initFindRideMap() {
 
-  // Virginia locations
-  var westva = {lat: 38.7624, lng: -79.7170677};
-  var sweetbriar = {lat: 37.5551696, lng: -79.098562};
-
-  // Baltimore locations
-  var baltLocations = [
-    {lat: 39.3146481, lng: -76.6419097}, 
-    {lat: 39.336027, lng: -76.574490}, 
-    {lat: 39.278518, lng: -76.640065}, 
-    {lat: 39.277858, lng: -76.542218}, 
-    {lat: 39.351572, lng: -76.641438}
-  ];
-  var baltCenter = {lat: 39.314246, lng: -76.601955};
-  var markers = [];
-  var mapFindRide, mapGiveRide, mapMyRides, mapMini;
-
-function initFindRideMap() {
-
-  mapFindRide = new google.maps.Map(document.getElementById('background-map'), {
-    zoom: 12,
-    center: baltCenter,
-    styles: mapStyleDiscreet
-  });
-
-  for (var i=0; i < baltLocations.length; i++) {
-    markers.push(
-      new google.maps.Marker({
-        position: new google.maps.LatLng(baltLocations[i].lat, baltLocations[i].lng),
-        map: mapFindRide,
-        icon: normalIcon()
-      })
-    );
-  }
-}
-
-function initGiveRideMap() {
-
-  mapGiveRide = new google.maps.Map(document.getElementById('give-ride-map'), {
-    zoom: 12,
-    center: baltCenter,
-    styles: mapStyleDiscreet
-  });
-
-  for (var i=0; i < baltLocations.length; i++) {
-    markers.push(
-      new google.maps.Marker({
-        position: new google.maps.LatLng(baltLocations[i].lat, baltLocations[i].lng),
-        map: mapGiveRide,
-        icon: normalIcon()
-      })
-    );
-  }
-}
-
-function initMyRidesMap() {
-
-  mapMyRides = new google.maps.Map(document.getElementById('my-rides-map'), {
-    zoom: 12,
-    center: baltCenter,
-    styles: mapStyleDiscreet
-  });
-
-  for (var i=0; i < baltLocations.length; i++) {
-    markers.push(
-      new google.maps.Marker({
-        position: new google.maps.LatLng(baltLocations[i].lat, baltLocations[i].lng),
-        map: mapMyRides,
-        icon: normalIcon()
-      })
-    );
-  }
-}
-
-function initMiniMap() {
-
-  mapMini = new google.maps.Map(document.getElementById('mini-map'), {
-    zoom: 12,
-    center: baltCenter,
-    styles: mapStyleDiscreet
-  });
-
-  new google.maps.Marker({
-    position: new google.maps.LatLng(baltCenter.lat, baltCenter.lng),
-    map: mapMini,
-    icon: normalIcon()
-  });
-}
-
-function normalIcon() {
-  return {
-    url: 'img/ic_marker_inactive.svg'
-  };
-}
-function highlightedIcon() {
-  return {
-    url: 'img/ic_marker_active.svg'
-  };
-}
-
-var activeDetail = false;
-var navMenuOpen = false;
-
-$(document).ready(function() {
-  $('.results-box .result').hover(
-    // mouse in
-    function () {
-      var index = $('.results-box .result').index(this);
-      markers[index].setIcon(highlightedIcon());
-
-    },
-    // mouse out
-    function () {
-      var index = $('.results-box .result').index(this);
-      markers[index].setIcon(normalIcon());
-    }
-  );
-  $('.results-box .result').click( function () {
-    if (activeDetail == false) {
-      // open detail panel
-      activeDetail = true;
-      $('.right-bar').addClass("active");
-      $('.mobile-back-link').addClass("active");
-      // recenter map on current marker
-      var index = $('.results-box .result').index(this);
-      console.log(markers[index].position);
-      if ($(this).parent().hasClass('find-ride')) {
-        mapFindRide.setCenter(markers[index].position);
-      } else if ($(this).parent().hasClass('give-ride')) {
-        mapGiveRide.setCenter(markers[index].position);
-      } else if ($(this).parent().hasClass('my-rides')) {
-        mapMyRides.setCenter(markers[index].position);
-      }
-    } else {
-      // close detail panel
-      activeDetail = false;
-      $('.right-bar').removeClass("active");
-      $('.mobile-back-link').removeClass("active");
-    }
-  });
-  $('.mobile-back-link').click( function () {
-    if (activeDetail == true) {
-      // close detail panel
-      activeDetail = false;
-      $('.right-bar').removeClass("active");
-      $('.mobile-back-link').removeClass("active");
-    }
-  });
-  // Cross-browser date widget for /carpools/new page
-  $('input[type="date"]').each(function () {
-    $(this).dateTimePicker({
-      monthName: ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'],
-      dayName: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],
-      mode: 'date',
+    mapFindRide = new google.maps.Map(document.getElementById('background-map'), {
+      zoom: 12,
+      center: baltCenter,
+      styles: mapStyleDiscreet
     });
-  })
-});
+
+    for (var i=0; i < baltLocations.length; i++) {
+      markers.push(
+        new google.maps.Marker({
+          position: new google.maps.LatLng(baltLocations[i].lat, baltLocations[i].lng),
+          map: mapFindRide,
+          icon: normalIcon()
+        })
+      );
+    }
+  }
+
+  function initGiveRideMap() {
+
+    mapGiveRide = new google.maps.Map(document.getElementById('give-ride-map'), {
+      zoom: 12,
+      center: baltCenter,
+      styles: mapStyleDiscreet
+    });
+
+    for (var i=0; i < baltLocations.length; i++) {
+      markers.push(
+        new google.maps.Marker({
+          position: new google.maps.LatLng(baltLocations[i].lat, baltLocations[i].lng),
+          map: mapGiveRide,
+          icon: normalIcon()
+        })
+      );
+    }
+  }
+
+  function initMyRidesMap() {
+
+    mapMyRides = new google.maps.Map(document.getElementById('my-rides-map'), {
+      zoom: 12,
+      center: baltCenter,
+      styles: mapStyleDiscreet
+    });
+
+    for (var i=0; i < baltLocations.length; i++) {
+      markers.push(
+        new google.maps.Marker({
+          position: new google.maps.LatLng(baltLocations[i].lat, baltLocations[i].lng),
+          map: mapMyRides,
+          icon: normalIcon()
+        })
+      );
+    }
+  }
+
+  function initMiniMap() {
+
+    mapMini = new google.maps.Map(document.getElementById('mini-map'), {
+      zoom: 12,
+      center: baltCenter,
+      styles: mapStyleDiscreet
+    });
+
+    new google.maps.Marker({
+      position: new google.maps.LatLng(baltCenter.lat, baltCenter.lng),
+      map: mapMini,
+      icon: normalIcon()
+    });
+  }
+
+  function normalIcon() {
+    return {
+      url: 'img/ic_marker_inactive.svg'
+    };
+  }
+  function highlightedIcon() {
+    return {
+      url: 'img/ic_marker_active.svg'
+    };
+  }
+
+  var activeDetail = false;
+  var navMenuOpen = false;
+
+  $(document).ready(function() {
+    $('.results-box .result').hover(
+      // mouse in
+      function () {
+        var index = $('.results-box .result').index(this);
+        markers[index].setIcon(highlightedIcon());
+
+      },
+      // mouse out
+      function () {
+        var index = $('.results-box .result').index(this);
+        markers[index].setIcon(normalIcon());
+      }
+    );
+    $('.results-box .result').click( function () {
+      if (activeDetail == false) {
+        // open detail panel
+        activeDetail = true;
+        $('.right-bar').addClass("active");
+        $('.mobile-back-link').addClass("active");
+        // recenter map on current marker
+        var index = $('.results-box .result').index(this);
+        console.log(markers[index].position);
+        if ($(this).parent().hasClass('find-ride')) {
+          mapFindRide.setCenter(markers[index].position);
+        } else if ($(this).parent().hasClass('give-ride')) {
+          mapGiveRide.setCenter(markers[index].position);
+        } else if ($(this).parent().hasClass('my-rides')) {
+          mapMyRides.setCenter(markers[index].position);
+        }
+      } else {
+        // close detail panel
+        activeDetail = false;
+        $('.right-bar').removeClass("active");
+        $('.mobile-back-link').removeClass("active");
+      }
+    });
+    $('.mobile-back-link').click( function () {
+      if (activeDetail == true) {
+        // close detail panel
+        activeDetail = false;
+        $('.right-bar').removeClass("active");
+        $('.mobile-back-link').removeClass("active");
+      }
+    });
+    // Cross-browser date widget for /carpools/new page
+    $('input[type="date"]').each(function () {
+      $(this).dateTimePicker({
+        monthName: ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'],
+        dayName: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],
+        mode: 'date',
+      });
+    })
+  });
+})()
+
+
 
 


### PR DESCRIPTION
Fixing issue #740 by wrapping the `find.js` and `script.js` scripts in IIFEs per @dryan suggestion. Some notes:

- The functions `setLatLng` and `localInitMap` in `find.js` need to be global since they are invoked in the `_template.html` file. I've attached them to the `window` object explicitly at the top of the `find.js` IIFE.
- I'm unclear how the `script.js` script is supposed to work for the following reasongs:
  - The lat/lon combos in the file seem to be hardcoded to Virginia and Baltimore locations, and don't seem to get amended by a user's location search, so the markers referenced in other functions in the file aren't accurate.
  - Many of the functions don't seem to be invoked at all, either within the file or globally (e.g. `initFindRideMap`, `initGiveRideMap`, `initMyRidesMap`, `initMiniMap`).  Couldn't find references after `grep`ping the codebase.
  - Many of the event handlers in the script (e.g. `$('.results-box .result').hover`, `$('.results-box .result').click`) don't seem to work properly since the `.result` DOM nodes they are referencing often don't exist on the page at load time when the listeners are attached. A simple fix to this would be to use [event delegation](https://learn.jquery.com/events/event-delegation/) to listen for events on the `.results-box` as a whole, instead of the individual nodes. I tried implementing this, but it still didn't work because of the hardcoded lat/lon combos mentioned above.

I checked to make sure the map loaded correctly and recentered itself properly after a search - beyond that, I'm not sure which functionality this change would affect.